### PR TITLE
Support rectangular text selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ pkill -USR1 monstar
 | `Ctrl+-` | Decrease font size for this window |
 | `Ctrl+0` | Reset font size for this window |
 | `Ctrl` + left click | Open OSC 8 hyperlink |
+| `Ctrl` + drag | Rectangular text selection |

--- a/src/App.zig
+++ b/src/App.zig
@@ -168,6 +168,8 @@ scroll_had_discrete: bool,
 scroll_had_value120: bool,
 /// True while the left button is down for terminal-side selection.
 selecting: bool,
+/// True when the active drag should produce a rectangular selection.
+selection_rectangle: bool,
 selection_gesture: vt.SelectionGesture,
 /// Button press currently owned by application mouse reporting.
 mouse_button: ?vt.input.MouseButton,
@@ -523,6 +525,7 @@ pub fn init(
         .scroll_had_discrete = false,
         .scroll_had_value120 = false,
         .selecting = false,
+        .selection_rectangle = false,
         .selection_gesture = .init,
         .mouse_button = null,
         .mouse_shape_explicit = false,
@@ -2464,6 +2467,7 @@ fn forwardMouseButton(self: *App, button: anytype, mouse_button: vt.input.MouseB
 fn startSelection(self: *App, time_ms: u32) void {
     const pin = self.pinAtPointer() orelse return;
     const pos = self.pointerPhysical();
+    self.selection_rectangle = self.keyboard.currentMods().ctrl;
     const selection = self.selection_gesture.press(&self.term, .{
         .time = selectionTimestamp(time_ms),
         .pin = pin,
@@ -2484,7 +2488,7 @@ fn extendSelection(self: *App) void {
         .pin = pin,
         .xpos = pos.x,
         .ypos = pos.y,
-        .rectangle = false,
+        .rectangle = self.selection_rectangle,
         .word_boundary_codepoints = &selection_word_boundaries,
         .geometry = self.selectionGeometry(),
     });
@@ -2496,6 +2500,7 @@ fn extendSelection(self: *App) void {
 /// that owns it (which may no longer be the active one).
 fn cancelDrag(self: *App) void {
     self.selecting = false;
+    self.selection_rectangle = false;
     self.selection_gesture.reset(&self.term);
     self.stopSelectionAutoscrollTimer();
 }
@@ -2504,6 +2509,7 @@ fn finishSelection(self: *App) void {
     if (!self.selecting) return;
     self.selecting = false;
     self.selection_gesture.release(&self.term, .{ .pin = self.pinAtPointer() });
+    self.selection_rectangle = false;
     self.stopSelectionAutoscrollTimer();
     // Finished selections claim the primary selection, X style.
     self.copyToPrimary();
@@ -2557,7 +2563,7 @@ fn fireSelectionAutoscroll(self: *App) void {
         .viewport = .{ .x = cell.x, .y = cell.y },
         .xpos = pos.x,
         .ypos = pos.y,
-        .rectangle = false,
+        .rectangle = self.selection_rectangle,
         .word_boundary_codepoints = &selection_word_boundaries,
         .geometry = self.selectionGeometry(),
     });

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -1736,6 +1736,63 @@ test "render a simple grid" {
     try std.testing.expect(non_bg > 0);
 }
 
+test "render rectangular selection spans" {
+    const alloc = std.testing.allocator;
+    const selection_bg: vt.color.RGB = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
+
+    var font: Font = try .init(alloc, "monospace", 16);
+    defer font.deinit(alloc);
+
+    var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 8, .rows = 5 });
+    defer term.deinit(alloc);
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("\x1b[?25l");
+
+    const screen = term.screens.active;
+    try screen.select(vt.Selection.init(
+        screen.pages.pin(.{ .active = .{ .x = 2, .y = 1 } }).?,
+        screen.pages.pin(.{ .active = .{ .x = 4, .y = 3 } }).?,
+        true,
+    ));
+
+    var state: vt.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &term);
+
+    const rows = state.row_data.slice();
+    const selections = rows.items(.selection);
+    try std.testing.expectEqual(null, selections[0]);
+    try std.testing.expectEqualSlices(vt.size.CellCountInt, &.{ 2, 4 }, &selections[1].?);
+    try std.testing.expectEqualSlices(vt.size.CellCountInt, &.{ 2, 4 }, &selections[2].?);
+    try std.testing.expectEqualSlices(vt.size.CellCountInt, &.{ 2, 4 }, &selections[3].?);
+    try std.testing.expectEqual(null, selections[4]);
+
+    var renderer: Renderer = try .init(alloc, &font, .{ .selection_background = selection_bg });
+    defer renderer.deinit();
+
+    const width: u31 = font.cell_width * 8;
+    const height: u31 = font.cell_height * 5;
+    const pixels = try alloc.alloc(u32, @as(usize, width) * height);
+    defer alloc.free(pixels);
+
+    try renderer.render(&state, pixels, width, height);
+
+    const selected = argb(selection_bg);
+    const background = argb(state.colors.background);
+    for (0..5) |y| {
+        for (0..8) |x| {
+            const px = (y * font.cell_height + font.cell_height / 2) * width +
+                (x * font.cell_width + font.cell_width / 2);
+            const expected = if (y >= 1 and y <= 3 and x >= 2 and x <= 4)
+                selected
+            else
+                background;
+            try std.testing.expectEqual(expected, pixels[px]);
+        }
+    }
+}
+
 test "render kitty image placement" {
     const alloc = std.testing.allocator;
 


### PR DESCRIPTION
## Summary
- enable rectangular text selection when Ctrl is held at the start of a terminal-side drag
- keep the rectangle mode stable for the lifetime of the drag, including autoscroll
- add a renderer regression test for rectangular per-row selection spans
- document the `Ctrl` + drag shortcut

Closes #12

## Demo

![Block selection demo](https://github.com/rockorager/monstar/releases/download/_attachments/block-selection-demo.gif)

[MP4 download](https://github.com/rockorager/monstar/releases/download/_attachments/block-selection-demo.mp4)

## Testing
- `zig build`
- `zig build test` *(fails one pre-existing test: `Font.test.embedded symbols face serves nerd font codepoints`; 39/40 pass, including the new rectangular-selection test)*
