### PR TITLE
renderer: apply faint (SGR 2) text intensity

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -27,6 +27,8 @@ const kittyDestRect = kitty_graphics.kittyDestRect;
 const kittyItemOpaque = kitty_graphics.kittyItemOpaque;
 const kitty_placeholder = vt.kitty.graphics.unicode.placeholder;
 const search_match_alpha = 128;
+/// Foreground weight for faint (SGR 2) text; the rest blends to background.
+const faint_alpha = 128;
 
 pub const ScrollbarThumb = pixel_raster.ScrollbarThumb;
 pub const KittyRenderItem = kitty_graphics.KittyRenderItem;
@@ -1280,6 +1282,8 @@ fn prepareRowCells(
             fg = bg orelse colors.background;
             bg = old_fg;
         }
+        // Faint (SGR 2) dims the glyph halfway toward its background.
+        if (style.flags.faint) fg = blendRgb(fg, bg orelse colors.background, faint_alpha);
         var background_uses_alpha = self.background_alpha_cells and bg != null;
         // Selection overrides cell colors: fixed background, default
         // foreground, so selected text reads uniformly.

--- a/src/pixel_raster.zig
+++ b/src/pixel_raster.zig
@@ -415,6 +415,16 @@ test "blend endpoints" {
     );
 }
 
+test "blendRgb faint dims foreground toward background" {
+    const white: vt.color.RGB = .{ .r = 0xff, .g = 0xff, .b = 0xff };
+    const black: vt.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
+    try std.testing.expectEqual(white, blendRgb(white, black, 255));
+    try std.testing.expectEqual(black, blendRgb(white, black, 0));
+    // Half blend (the faint weight) lands on mid-gray, dimmer than the source.
+    const gray: vt.color.RGB = .{ .r = 0x80, .g = 0x80, .b = 0x80 };
+    try std.testing.expectEqual(gray, blendRgb(white, black, 128));
+}
+
 test "scrollbar capsule has antialiased caps and a solid center" {
     const background: u32 = 0xff000000;
     var pixels = [_]u32{background} ** 48;


### PR DESCRIPTION
Faint text (`ESC[2m`) is tracked in the VT state but never applied at
render time, so dim text - shell autosuggestions, TUI hints, and the
like - renders identically to normal text.

### Repro

Before this change all three look identical; after, FAINT is dimmer:

    printf '\e[0mNORMAL\e[0m \e[2mFAINT\e[0m \e[1mBOLD\e[0m\n'
