### PR TITLE
keyboard: add scrollback navigation bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ settings apply to new windows.
 | `Ctrl+Shift+F` | Search scrollback |
 | `Ctrl+Shift+N` | Open a new window in the current directory |
 | `Ctrl+Shift+,` | Reload configuration |
+| `Shift+PageUp` / `Shift+PageDown` | Scroll back / forward one page |
+| `Shift+Home` / `Shift+End` | Scroll to the top / bottom of scrollback |
 | `Ctrl++` / `Ctrl+=` / `Ctrl+-` | Adjust the font size |
 | `Ctrl+0` | Reset the font size |
 | `Ctrl` + left click | Open a hyperlink or detected URI |
@@ -236,6 +238,8 @@ settings apply to new windows.
 Scrollback search updates as you type. Press `Ctrl+N` and `Ctrl+P` to move
 between matches. Press `Enter` to copy a match to the primary selection. Press
 `Escape` to restore the previous viewport.
+
+Scrollback keybindings pass through to applications using the alternate screen.
 
 Hold `Shift` while dragging to select text after an application captures the
 mouse. Hold `Ctrl+Shift` instead of `Ctrl` to open a link in this state.

--- a/dist/monstar.1
+++ b/dist/monstar.1
@@ -197,6 +197,14 @@ Jump to the next OSC 133 prompt.
 .TP
 .B Ctrl+Shift+Z
 Jump to the previous OSC 133 prompt.
+.TP
+.BR Shift+PageUp " or " Shift+PageDown
+Scroll backward or forward by one terminal page.
+.TP
+.BR Shift+Home " or " Shift+End
+Scroll to the top or bottom of the terminal scrollback.
+.PP
+Scrollback shortcuts pass through to applications using the alternate screen.
 .SH POINTER INPUT
 Drag with the left button to select text.
 Hold

--- a/src/App.zig
+++ b/src/App.zig
@@ -4335,6 +4335,49 @@ fn handleSearchKey(self: *App, event: vt.input.KeyEvent) void {
     }
 }
 
+const ScrollbackKeyAction = enum {
+    page_up,
+    page_down,
+    top,
+    bottom,
+};
+
+fn scrollbackKeyAction(
+    active_screen: vt.ScreenSet.Key,
+    event: vt.input.KeyEvent,
+) ?ScrollbackKeyAction {
+    // Like foot, leave scrollback shortcuts to full-screen applications.
+    if (active_screen != .primary or !event.mods.shift or
+        event.mods.ctrl or event.mods.alt or event.mods.super) return null;
+
+    return switch (event.key) {
+        .page_up => .page_up,
+        .page_down => .page_down,
+        .home => .top,
+        .end => .bottom,
+        else => null,
+    };
+}
+
+fn handleScrollbackKey(self: *App, event: vt.input.KeyEvent) bool {
+    const scroll = scrollbackKeyAction(self.term.screens.active_key, event) orelse return false;
+    // Consume the matching release too, but move only on press/repeat.
+    if (event.action == .release) return true;
+
+    self.stopFling();
+    const rows: isize = @intCast(self.term.rows);
+    switch (scroll) {
+        .page_up => self.term.screens.active.pages.scroll(.{ .delta_row = -rows }),
+        .page_down => self.term.screens.active.pages.scroll(.{ .delta_row = rows }),
+        .top => self.term.screens.active.pages.scroll(.top),
+        .bottom => self.term.screens.active.pages.scroll(.active),
+    }
+    self.revealScrollbar();
+    self.needs_redraw = true;
+    self.syncHoveredLink(true);
+    return true;
+}
+
 fn onKey(self: *App, evdev_keycode: u32, action: vt.input.KeyAction) void {
     var utf8_buf: [16]u8 = undefined;
     const event = self.keyboard.translate(&utf8_buf, evdev_keycode, action) orelse return;
@@ -4364,6 +4407,8 @@ fn onKey(self: *App, evdev_keycode: u32, action: vt.input.KeyAction) void {
             else => {},
         }
     }
+
+    if (self.handleScrollbackKey(event)) return;
 
     const wrote = self.encodeAndWriteKey(event);
 
@@ -5207,6 +5252,42 @@ test "search backspace removes one UTF-8 codepoint" {
     try std.testing.expectEqualStrings("a", query.items);
     try std.testing.expect(truncateLastUtf8(&query));
     try std.testing.expect(!truncateLastUtf8(&query));
+}
+
+test "scrollback keys require shift on the primary screen" {
+    const shifted: vt.input.KeyMods = .{ .shift = true };
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.page_up,
+        scrollbackKeyAction(.primary, .{ .key = .page_up, .mods = shifted }).?,
+    );
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.page_down,
+        scrollbackKeyAction(.primary, .{ .key = .page_down, .mods = shifted }).?,
+    );
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.top,
+        scrollbackKeyAction(.primary, .{ .key = .home, .mods = shifted }).?,
+    );
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.bottom,
+        scrollbackKeyAction(.primary, .{ .key = .end, .mods = shifted }).?,
+    );
+
+    try std.testing.expectEqual(
+        null,
+        scrollbackKeyAction(.alternate, .{ .key = .page_up, .mods = shifted }),
+    );
+    try std.testing.expectEqual(
+        null,
+        scrollbackKeyAction(.primary, .{ .key = .page_up }),
+    );
+    try std.testing.expectEqual(
+        null,
+        scrollbackKeyAction(.primary, .{
+            .key = .page_up,
+            .mods = .{ .shift = true, .ctrl = true },
+        }),
+    );
 }
 
 test "scrollback search scrolls a history match into the viewport" {


### PR DESCRIPTION
## Summary

- bind Shift+PageUp and Shift+PageDown to full-viewport scrollback movement
- bind Shift+Home and Shift+End to the top and bottom of scrollback
- pass the shortcuts through to alternate-screen applications, matching foot
- document the new shortcuts in the README and man page

Fixes #23

## Test plan

- `zig build test`
- `zig fmt --check src/App.zig`
- `git diff --check`