### PR TITLE
deps: bump ghostty and z2d

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,16 +5,16 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty.git#7aa9591746ffa4d2eee458960c76554352832595",
-            .hash = "ghostty-1.3.2-dev-5UdBC-edJAVXTdYsgHOzIqgAI7hE8VqpmriEi8zgufw2",
+            .url = "git+https://github.com/ghostty-org/ghostty.git#2dd79f3bc6af649e68422b08e21ad0300fd8b391",
+            .hash = "ghostty-1.3.2-dev-5UdBC4JhJgXdhefpqPX727nCW5VepJv5QfDEU3nwsyDM",
         },
         .wayland = .{
             .url = "git+https://codeberg.org/ifreund/zig-wayland#a8e10e87e5ebb49ce518ac3d2198909c87ee615a",
             .hash = "wayland-0.7.0-dev-lQa1kjT8AQDBstL61Gy3WCMtGwVaMN1p6w5wGfdDvP15",
         },
         .z2d = .{
-            .url = "git+https://github.com/vancluever/z2d#3edb5d1bba7192352c17592a218eca8b646679dc",
-            .hash = "z2d-0.12.0-j5P_HsE8EQAuRulQMsEkrCevU85rTFl4JIOz7uJdCYA-",
+            .url = "git+https://github.com/vancluever/z2d#47fc1030c1636dcfb75ea1cc238f706dd1feb379",
+            .hash = "z2d-0.12.2-pre-j5P_HtA8EQDpzu5RUtQhr_Sn9MeQF3_q7rWMw3ouesd0",
         },
         .iterm2_themes = .{
             .url = "https://deps.files.ghostty.org/ghostty-themes-release-20260629-161812-8c97c3c.tgz",

--- a/src/App.zig
+++ b/src/App.zig
@@ -467,7 +467,7 @@ pub fn init(
     var term: vt.Terminal = try .init(io, alloc, .{
         .cols = startup_size.cols,
         .rows = startup_size.rows,
-        .max_scrollback = config.scrollback_limit,
+        .max_scrollback_bytes = config.scrollback_limit,
         .colors = config.terminalColors(.dark),
         .default_modes = .{ .grapheme_cluster = true },
         // libghostty-vt defaults to a conservative 10MB, which rejects a
@@ -5295,7 +5295,7 @@ test "scrollback search scrolls a history match into the viewport" {
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{
         .cols = 16,
         .rows = 3,
-        .max_scrollback = 100,
+        .max_scrollback_bytes = 100,
     });
     defer term.deinit(alloc);
     var stream = term.vtStream();

--- a/src/ScrollDetector.zig
+++ b/src/ScrollDetector.zig
@@ -131,7 +131,7 @@ test "scroll detector finds viewport shifts and narrows dirty rows" {
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{
         .cols = 10,
         .rows = 4,
-        .max_scrollback = 100,
+        .max_scrollback_bytes = 100,
     });
     defer term.deinit(alloc);
     var stream = term.vtStream();

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -34,7 +34,7 @@ pub fn run(init: std.process.Init) !void {
     var term: vt.Terminal = try .init(init.io, alloc, .{
         .cols = cols,
         .rows = rows,
-        .max_scrollback = config.scrollback_limit,
+        .max_scrollback_bytes = config.scrollback_limit,
         .colors = config.terminalColors(.dark),
     });
     defer term.deinit(alloc);
@@ -206,7 +206,7 @@ fn benchFullGrid(
     var term: vt.Terminal = try .init(io, alloc, .{
         .cols = bench_cols,
         .rows = bench_rows,
-        .max_scrollback = config.scrollback_limit,
+        .max_scrollback_bytes = config.scrollback_limit,
         .colors = config.terminalColors(.dark),
     });
     defer term.deinit(alloc);
@@ -313,7 +313,7 @@ fn benchShapePrefixChurn(
     var term: vt.Terminal = try .init(io, alloc, .{
         .cols = bench_cols,
         .rows = bench_rows,
-        .max_scrollback = config.scrollback_limit,
+        .max_scrollback_bytes = config.scrollback_limit,
         .colors = config.terminalColors(.dark),
     });
     defer term.deinit(alloc);


### PR DESCRIPTION
Update ghostty past the Terminal.Options scrollback split, which replaces max_scrollback with separate max_scrollback_bytes and max_scrollback_lines limits. Point the byte-based scrollback-limit config at the new max_scrollback_bytes field and leave the row-based limit unlimited, which preserves the previous behavior.

Bump z2d to 0.12.2-pre in the same step.

I used Opus 5 with Claude Code for this change with manual review and testing. The update tracks the latest Ghostty PRs that introduced a breaking change in scrollback - https://github.com/ghostty-org/ghostty/pull/13473. This PR also bumps `z2d` in line with Ghostty - https://github.com/ghostty-org/ghostty/pull/13489 (one commit ahead)