### PR TITLE
flake: add nix packaging for monstar

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,17 @@
 
   outputs = { self, nixpkgs }:
     let
-      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+      inherit (nixpkgs) lib;
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      buildInputs = pkgs: [
+        pkgs.wayland
+        pkgs.wayland-scanner
+        pkgs.wayland-protocols
+        pkgs.fontconfig
+        pkgs.freetype
+        pkgs.harfbuzz
+        pkgs.libxkbcommon
+      ];
     in
     {
       packages = forAllSystems (system:
@@ -18,6 +28,9 @@
             version = "1.0.1";
             src = self;
 
+            nativeBuildInputs = [ pkgs.zig pkgs.pkg-config ];
+            buildInputs = buildInputs pkgs;
+
             zigDeps = pkgs.zig.fetchDeps {
               inherit (finalAttrs) src pname version;
               fetchAll = true;
@@ -27,28 +40,13 @@
             postConfigure = ''
               ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
             '';
-
-            nativeBuildInputs = [
-              pkgs.zig
-              pkgs.pkg-config
-            ];
-
-            buildInputs = [
-              pkgs.wayland
-              pkgs.wayland-scanner
-              pkgs.wayland-protocols
-              pkgs.fontconfig
-              pkgs.freetype
-              pkgs.harfbuzz
-              pkgs.libxkbcommon
-            ];
           });
         });
 
       apps = forAllSystems (system: {
         default = {
           type = "app";
-          program = "${self.packages.${system}.default}/bin/monstar";
+          program = lib.getExe' self.packages.${system}.default "monstar";
         };
       });
 
@@ -59,15 +57,7 @@
         {
           default = pkgs.mkShell {
             nativeBuildInputs = [ pkgs.zig pkgs.pkg-config ];
-            buildInputs = [
-              pkgs.wayland
-              pkgs.wayland-scanner
-              pkgs.wayland-protocols
-              pkgs.fontconfig
-              pkgs.freetype
-              pkgs.harfbuzz
-              pkgs.libxkbcommon
-            ];
+            buildInputs = buildInputs pkgs;
           };
         });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
   outputs = { self, nixpkgs }:
     let
       inherit (nixpkgs) lib;
-      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      linuxSystems = builtins.filter
+        (system: (lib.systems.elaborate system).isLinux)
+        lib.systems.flakeExposed;
+      forAllSystems = lib.genAttrs linuxSystems;
       buildInputs = pkgs: [
         pkgs.wayland
         pkgs.wayland-scanner

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "Monstar — Wayland terminal emulator";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation (finalAttrs: {
+            pname = "monstar";
+            version = "1.0.1";
+            src = self;
+
+            zigDeps = pkgs.zig.fetchDeps {
+              inherit (finalAttrs) src pname version;
+              fetchAll = true;
+              hash = "sha256-uAedHwfkI3NrdiRJ90gy4fcg9n/N4xmx3bq15m1h1oU=";
+            };
+
+            postConfigure = ''
+              ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+            '';
+
+            nativeBuildInputs = [
+              pkgs.zig
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.wayland
+              pkgs.wayland-scanner
+              pkgs.wayland-protocols
+              pkgs.fontconfig
+              pkgs.freetype
+              pkgs.harfbuzz
+              pkgs.libxkbcommon
+            ];
+          });
+        });
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/monstar";
+        };
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            nativeBuildInputs = [ pkgs.zig pkgs.pkg-config ];
+            buildInputs = [
+              pkgs.wayland
+              pkgs.wayland-scanner
+              pkgs.wayland-protocols
+              pkgs.fontconfig
+              pkgs.freetype
+              pkgs.harfbuzz
+              pkgs.libxkbcommon
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
Adds a Nix flake for building monstar as a package, app, and dev shell.

- `packages.default` — builds monstar with Zig + Wayland deps
- `apps.default` — runs the built binary
- `devShells.default` — Zig dev environment with required buildInputs

Uses `zig.fetchDeps` with a checked-in lockfile hash for reproducible builds.