### PR TITLE
Add -Dcpu=baseline flag to build-binary-dist.sh

### DIFF
--- a/packaging/build-binary-dist.sh
+++ b/packaging/build-binary-dist.sh
@@ -30,7 +30,7 @@ rm -rf "$STAGING_DIR" dist/monstar-*.tar.gz \
 mkdir -p "$STAGING_DIR/${ARCHIVE_ROOT}"
 
 # Build stripped ReleaseFast release prefix
-zig build -Doptimize=ReleaseFast -Dstrip=true --prefix "$STAGING_DIR/${ARCHIVE_ROOT}"
+zig build -Doptimize=ReleaseFast -Dstrip=true -Dcpu=baseline --prefix "$STAGING_DIR/${ARCHIVE_ROOT}"
 
 EXPECTED_VERSION="monstar ${VERSION}"
 ACTUAL_VERSION=$("$STAGING_DIR/${ARCHIVE_ROOT}/bin/monstar" --version)


### PR DESCRIPTION
Fixes #41

The same flag is preset in both `packaging/arch/monstar-git.PKGBUILD.in` and `packaging/arch/monstar.PKGBUILD.in`.