### PR TITLE
config: add line-height override

### DIFF
--- a/dist/monstar.5
+++ b/dist/monstar.5
@@ -117,6 +117,20 @@ Fractional values greater than zero and no greater than 512 are accepted.
 The default is
 .BR 12pt ,
 equivalent to 16 logical pixels at 96 DPI.
+.TP
+.BI line-height " = size[pt|px]"
+Set the line height, overriding the height derived from the font metrics.
+Units follow
+.BR font-size :
+bare values and
+.B pt
+are typographic points;
+.B px
+are logical pixels before Wayland output scaling.
+Glyphs are vertically centered within the taller or shorter cell; a value
+below the font's natural height may clip text, and runtime font size changes
+scale the line height by the same ratio.
+By default the line height comes from the font metrics.
 .SH WINDOW SETTINGS
 .TP
 .BI background-opacity " = opacity"

--- a/dist/monstar.5
+++ b/dist/monstar.5
@@ -118,19 +118,21 @@ The default is
 .BR 12pt ,
 equivalent to 16 logical pixels at 96 DPI.
 .TP
-.BI line-height " = size[pt|px]"
-Set the line height, overriding the height derived from the font metrics.
-Units follow
-.BR font-size :
-bare values and
-.B pt
-are typographic points;
-.B px
-are logical pixels before Wayland output scaling.
-Glyphs are vertically centered within the taller or shorter cell; a value
-below the font's natural height may clip text, and runtime font size changes
-scale the line height by the same ratio.
-By default the line height comes from the font metrics.
+.BI adjust-cell-height " = pixels|percent%"
+Adjust the height derived from the font metrics.
+A signed integer adds or removes physical pixels; a percentage scales the
+natural height.
+For example,
+.B 2
+adds two pixels,
+.B -2
+removes two pixels, and
+.B 20%
+increases the natural height by twenty percent.
+The result is at least one pixel, and glyphs remain vertically centered.
+Pixel adjustments stay fixed while zooming or changing output scale;
+percentage adjustments follow the font metrics.
+By default no adjustment is applied.
 .SH WINDOW SETTINGS
 .TP
 .BI background-opacity " = opacity"

--- a/src/App.zig
+++ b/src/App.zig
@@ -446,7 +446,12 @@ pub fn init(
     options: InitOptions,
 ) !*App {
     const font_size_px = Config.fontSizePixels(config.font_size, 120);
-    var font: Font = try .init(alloc, config.font_family, font_size_px);
+    var font: Font = try .init(
+        alloc,
+        config.font_family,
+        font_size_px,
+        config.lineHeightPixels(font_size_px, 120),
+    );
     errdefer font.deinit(alloc);
 
     vt.sys.decode_png = decodePng;
@@ -800,7 +805,12 @@ fn scaleChanged(ctx: *anyopaque, scale120: u32) anyerror!void {
     const size_px = Config.fontSizePixels(self.effectiveFontSize(), scale120);
     if (size_px == 0 or size_px == self.font_size_px) return;
 
-    const new_font: Font = try .init(self.alloc, self.config.font_family, size_px);
+    const new_font: Font = try .init(
+        self.alloc,
+        self.config.font_family,
+        size_px,
+        self.config.lineHeightPixels(size_px, scale120),
+    );
     self.font.deinit(self.alloc);
     self.font = new_font;
     self.font_size_px = size_px;
@@ -2036,7 +2046,12 @@ fn spawnEnvp(
 
 fn applyConfig(self: *App, new_config: Config) !void {
     const desired_font_size = Config.fontSizePixels(self.runtime_font_size orelse new_config.font_size, self.window.scale120);
-    const new_font: Font = try .init(self.alloc, new_config.font_family, desired_font_size);
+    const new_font: Font = try .init(
+        self.alloc,
+        new_config.font_family,
+        desired_font_size,
+        new_config.lineHeightPixels(desired_font_size, self.window.scale120),
+    );
 
     self.applyColorDefaultsForConfig(new_config);
     self.window.setBufferAlpha(new_config.background_opacity < 255);
@@ -2122,7 +2137,12 @@ fn effectiveFontSize(self: *const App) Config.FontSize {
 fn setRuntimeFontSize(self: *App, configured_size: ?Config.FontSize) void {
     const next_size = configured_size orelse self.config.font_size;
     const size_px = Config.fontSizePixels(next_size, self.window.scale120);
-    const new_font: Font = Font.init(self.alloc, self.config.font_family, size_px) catch |err| {
+    const new_font: Font = Font.init(
+        self.alloc,
+        self.config.font_family,
+        size_px,
+        self.config.lineHeightPixels(size_px, self.window.scale120),
+    ) catch |err| {
         log.warn("font size change failed: {}", .{err});
         return;
     };

--- a/src/App.zig
+++ b/src/App.zig
@@ -450,7 +450,7 @@ pub fn init(
         alloc,
         config.font_family,
         font_size_px,
-        config.lineHeightPixels(font_size_px, 120),
+        config.adjust_cell_height,
     );
     errdefer font.deinit(alloc);
 
@@ -809,7 +809,7 @@ fn scaleChanged(ctx: *anyopaque, scale120: u32) anyerror!void {
         self.alloc,
         self.config.font_family,
         size_px,
-        self.config.lineHeightPixels(size_px, scale120),
+        self.config.adjust_cell_height,
     );
     self.font.deinit(self.alloc);
     self.font = new_font;
@@ -2050,7 +2050,7 @@ fn applyConfig(self: *App, new_config: Config) !void {
         self.alloc,
         new_config.font_family,
         desired_font_size,
-        new_config.lineHeightPixels(desired_font_size, self.window.scale120),
+        new_config.adjust_cell_height,
     );
 
     self.applyColorDefaultsForConfig(new_config);
@@ -2141,7 +2141,7 @@ fn setRuntimeFontSize(self: *App, configured_size: ?Config.FontSize) void {
         self.alloc,
         self.config.font_family,
         size_px,
-        self.config.lineHeightPixels(size_px, self.window.scale120),
+        self.config.adjust_cell_height,
     ) catch |err| {
         log.warn("font size change failed: {}", .{err});
         return;

--- a/src/AsyncRaster.zig
+++ b/src/AsyncRaster.zig
@@ -680,7 +680,7 @@ test "unchanged dirty rows report no damage" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var raster = try AsyncRaster.init(
         font.discovery(),

--- a/src/AsyncRaster.zig
+++ b/src/AsyncRaster.zig
@@ -680,7 +680,7 @@ test "unchanged dirty rows report no damage" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var raster = try AsyncRaster.init(
         font.discovery(),

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -61,15 +61,41 @@ pub const FontSize = union(enum) {
     }
 };
 
+/// Adjustment applied to a font's natural cell height. Absolute values are
+/// physical pixel deltas; percentages scale with the natural metrics.
+pub const MetricModifier = union(enum) {
+    absolute: i32,
+    percent: f64,
+
+    pub fn apply(self: MetricModifier, natural: u31) u31 {
+        return switch (self) {
+            .absolute => |delta| @intCast(std.math.clamp(
+                @as(i64, natural) + delta,
+                1,
+                std.math.maxInt(u31),
+            )),
+            .percent => |percent| percent: {
+                const multiplier = @max(0, 1 + percent / 100);
+                const adjusted = @round(@as(f64, @floatFromInt(natural)) * multiplier);
+                break :percent @intFromFloat(std.math.clamp(
+                    adjusted,
+                    1,
+                    @as(f64, @floatFromInt(std.math.maxInt(u31))),
+                ));
+            },
+        };
+    }
+};
+
 /// Wayland app-id and desktop-entry hint for desktop integration.
 app_id: [:0]const u8 = default_app_id,
 font_family: [:0]const u8 = "monospace",
 /// Bare and `pt` values are typographic points; `px` values are logical
 /// pixels. Both apply the output's fractional scale during rasterization.
 font_size: FontSize = .{ .points = 12 },
-/// Absolute cell-height override like foot's `line-height`; unset uses
-/// the font's natural metrics.
-line_height: ?FontSize = null,
+/// Signed physical-pixel or percentage adjustment to the font's natural cell
+/// height. Unset preserves the natural metrics.
+adjust_cell_height: ?MetricModifier = null,
 /// Minimum window padding in logical pixels. One configured value applies to
 /// both sides; two values are left/right for X and top/bottom for Y.
 window_padding_x: WindowPadding = .{},
@@ -206,8 +232,8 @@ pub fn set(self: *Config, arena: std.mem.Allocator, key: []const u8, value: []co
         self.font_family = try arena.dupeZ(u8, value);
     } else if (std.mem.eql(u8, key, "font-size")) {
         self.font_size = try parseFontSize(value);
-    } else if (std.mem.eql(u8, key, "line-height")) {
-        self.line_height = try parseFontSize(value);
+    } else if (std.mem.eql(u8, key, "adjust-cell-height")) {
+        self.adjust_cell_height = try parseMetricModifier(value);
     } else if (std.mem.eql(u8, key, "window-padding-x")) {
         self.window_padding_x = try parseWindowPadding(value);
     } else if (std.mem.eql(u8, key, "window-padding-y")) {
@@ -294,6 +320,20 @@ fn parseFontSize(value: []const u8) error{InvalidValue}!FontSize {
     return switch (unit) {
         .points => .{ .points = size },
         .pixels => .{ .pixels = size },
+    };
+}
+
+fn parseMetricModifier(value: []const u8) error{InvalidValue}!MetricModifier {
+    const trimmed = std.mem.trim(u8, value, " \t");
+    if (std.mem.endsWith(u8, trimmed, "%")) {
+        const number = trimmed[0 .. trimmed.len - 1];
+        if (number.len == 0) return error.InvalidValue;
+        const percent = std.fmt.parseFloat(f64, number) catch return error.InvalidValue;
+        if (!std.math.isFinite(percent)) return error.InvalidValue;
+        return .{ .percent = percent };
+    }
+    return .{
+        .absolute = std.fmt.parseInt(i32, trimmed, 10) catch return error.InvalidValue,
     };
 }
 
@@ -387,17 +427,6 @@ pub fn fontSizePixels(size: FontSize, scale120: u32) u31 {
     };
     const pixels = logical_pixels * output_scale;
     return @max(1, @as(u31, @intFromFloat(@round(pixels))));
-}
-
-/// Resolves the line-height override to physical pixels for a font
-/// rendering at `font_size_px`, scaled by the font's zoom ratio like
-/// foot. Returns 0 when unset.
-pub fn lineHeightPixels(self: *const Config, font_size_px: u31, scale120: u32) u31 {
-    const lh = self.line_height orelse return 0;
-    const ratio = @as(f64, @floatFromInt(font_size_px)) /
-        @as(f64, @floatFromInt(fontSizePixels(self.font_size, scale120)));
-    const scaled = @round(@as(f64, @floatFromInt(fontSizePixels(lh, scale120))) * ratio);
-    return @intFromFloat(@max(1, scaled));
 }
 
 pub const colorsForScheme = config_theme.colorsForScheme;
@@ -739,21 +768,30 @@ test "font size accepts bare points and explicit point or pixel units" {
     try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "font-size", "px"));
 }
 
-test "line height parses units and scales with font zoom" {
+test "cell height adjustment accepts signed pixels and percentages" {
     var config: Config = .{};
-    try std.testing.expectEqual(@as(?FontSize, null), config.line_height);
-    try config.set(std.testing.allocator, "line-height", "1.5");
-    try std.testing.expectEqual(FontSize{ .points = 1.5 }, config.line_height.?);
-    try config.set(std.testing.allocator, "line-height", "20px");
-    try std.testing.expectEqual(FontSize{ .pixels = 20 }, config.line_height.?);
-    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "line-height", "-1"));
-    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "line-height", ""));
+    try std.testing.expectEqual(@as(?MetricModifier, null), config.adjust_cell_height);
 
-    // 12pt at scale 120 is 16px: unset resolves to 0, 20px stays 20px,
-    // and zooming the font to 24px scales the line height to 30px.
-    try std.testing.expectEqual(@as(u31, 20), config.lineHeightPixels(16, 120));
-    try std.testing.expectEqual(@as(u31, 30), config.lineHeightPixels(24, 120));
-    try std.testing.expectEqual(@as(u31, 0), (Config{}).lineHeightPixels(24, 120));
+    try config.set(std.testing.allocator, "adjust-cell-height", "2");
+    try std.testing.expectEqual(MetricModifier{ .absolute = 2 }, config.adjust_cell_height.?);
+    try std.testing.expectEqual(@as(u31, 22), config.adjust_cell_height.?.apply(20));
+
+    try config.set(std.testing.allocator, "adjust-cell-height", "-2");
+    try std.testing.expectEqual(MetricModifier{ .absolute = -2 }, config.adjust_cell_height.?);
+    try std.testing.expectEqual(@as(u31, 18), config.adjust_cell_height.?.apply(20));
+
+    try config.set(std.testing.allocator, "adjust-cell-height", "20%");
+    try std.testing.expectEqual(MetricModifier{ .percent = 20 }, config.adjust_cell_height.?);
+    try std.testing.expectEqual(@as(u31, 24), config.adjust_cell_height.?.apply(20));
+
+    try config.set(std.testing.allocator, "adjust-cell-height", "-150%");
+    try std.testing.expectEqual(@as(u31, 1), config.adjust_cell_height.?.apply(20));
+    try std.testing.expectEqual(@as(u31, 1), (MetricModifier{ .absolute = -100 }).apply(20));
+
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "adjust-cell-height", "1.5"));
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "adjust-cell-height", "2px"));
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "adjust-cell-height", "nan%"));
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "adjust-cell-height", ""));
 }
 
 test "invalid window padding keeps the previous value" {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -67,6 +67,9 @@ font_family: [:0]const u8 = "monospace",
 /// Bare and `pt` values are typographic points; `px` values are logical
 /// pixels. Both apply the output's fractional scale during rasterization.
 font_size: FontSize = .{ .points = 12 },
+/// Absolute cell-height override like foot's `line-height`; unset uses
+/// the font's natural metrics.
+line_height: ?FontSize = null,
 /// Minimum window padding in logical pixels. One configured value applies to
 /// both sides; two values are left/right for X and top/bottom for Y.
 window_padding_x: WindowPadding = .{},
@@ -203,6 +206,8 @@ pub fn set(self: *Config, arena: std.mem.Allocator, key: []const u8, value: []co
         self.font_family = try arena.dupeZ(u8, value);
     } else if (std.mem.eql(u8, key, "font-size")) {
         self.font_size = try parseFontSize(value);
+    } else if (std.mem.eql(u8, key, "line-height")) {
+        self.line_height = try parseFontSize(value);
     } else if (std.mem.eql(u8, key, "window-padding-x")) {
         self.window_padding_x = try parseWindowPadding(value);
     } else if (std.mem.eql(u8, key, "window-padding-y")) {
@@ -382,6 +387,17 @@ pub fn fontSizePixels(size: FontSize, scale120: u32) u31 {
     };
     const pixels = logical_pixels * output_scale;
     return @max(1, @as(u31, @intFromFloat(@round(pixels))));
+}
+
+/// Resolves the line-height override to physical pixels for a font
+/// rendering at `font_size_px`, scaled by the font's zoom ratio like
+/// foot. Returns 0 when unset.
+pub fn lineHeightPixels(self: *const Config, font_size_px: u31, scale120: u32) u31 {
+    const lh = self.line_height orelse return 0;
+    const ratio = @as(f64, @floatFromInt(font_size_px)) /
+        @as(f64, @floatFromInt(fontSizePixels(self.font_size, scale120)));
+    const scaled = @round(@as(f64, @floatFromInt(fontSizePixels(lh, scale120))) * ratio);
+    return @intFromFloat(@max(1, scaled));
 }
 
 pub const colorsForScheme = config_theme.colorsForScheme;
@@ -721,6 +737,23 @@ test "font size accepts bare points and explicit point or pixel units" {
     try std.testing.expectEqual(FontSize{ .pixels = 16.5 }, config.font_size);
     try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "font-size", "12em"));
     try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "font-size", "px"));
+}
+
+test "line height parses units and scales with font zoom" {
+    var config: Config = .{};
+    try std.testing.expectEqual(@as(?FontSize, null), config.line_height);
+    try config.set(std.testing.allocator, "line-height", "1.5");
+    try std.testing.expectEqual(FontSize{ .points = 1.5 }, config.line_height.?);
+    try config.set(std.testing.allocator, "line-height", "20px");
+    try std.testing.expectEqual(FontSize{ .pixels = 20 }, config.line_height.?);
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "line-height", "-1"));
+    try std.testing.expectError(error.InvalidValue, config.set(std.testing.allocator, "line-height", ""));
+
+    // 12pt at scale 120 is 16px: unset resolves to 0, 20px stays 20px,
+    // and zooming the font to 24px scales the line height to 30px.
+    try std.testing.expectEqual(@as(u31, 20), config.lineHeightPixels(16, 120));
+    try std.testing.expectEqual(@as(u31, 30), config.lineHeightPixels(24, 120));
+    try std.testing.expectEqual(@as(u31, 0), (Config{}).lineHeightPixels(24, 120));
 }
 
 test "invalid window padding keeps the previous value" {

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -13,6 +13,7 @@ const Font = @This();
 const std = @import("std");
 const c = @import("c");
 const uucode = @import("uucode");
+const Config = @import("Config.zig");
 const sprite = @import("sprite.zig");
 
 const log = std.log.scoped(.font);
@@ -62,6 +63,13 @@ cell_width: u31,
 cell_height: u31,
 /// Distance from the cell top to the text baseline.
 baseline: u31,
+/// Shrinking the cell can make glyphs overlap adjacent rows, so dirty-row
+/// rendering must repaint both neighbors.
+neighbor_row_overhang: bool,
+/// Extreme shrinking can make one glyph span multiple rows. The incremental
+/// renderer falls back to a full frame when its one-neighbor repair is
+/// insufficient.
+multi_row_overhang: bool,
 
 pub const Error = error{ FontNotFound, FontLoadFailed, GlyphResizeFailed, OutOfMemory };
 
@@ -101,11 +109,14 @@ pub const Discovery = struct {
     refs: std.atomic.Value(usize),
     family: [:0]u8,
     size_px: u31,
-    /// Cell height override in physical pixels; 0 uses natural metrics.
-    line_height_px: u31,
+    adjust_cell_height: ?Config.MetricModifier,
     sort_sets: [style_count]*c.FcFontSet,
 
-    fn init(family: [:0]const u8, size_px: u31, line_height_px: u31) Error!*Discovery {
+    fn init(
+        family: [:0]const u8,
+        size_px: u31,
+        adjust_cell_height: ?Config.MetricModifier,
+    ) Error!*Discovery {
         if (c.FcInit() != c.FcTrue) return error.FontLoadFailed;
 
         var sort_sets_opt: [style_count]?*c.FcFontSet = @splat(null);
@@ -123,12 +134,13 @@ pub const Discovery = struct {
 
         const alloc = std.heap.smp_allocator;
         const family_copy = try alloc.dupeZ(u8, family);
+        errdefer alloc.free(family_copy);
         const self = try alloc.create(Discovery);
         self.* = .{
             .refs = .init(1),
             .family = family_copy,
             .size_px = size_px,
-            .line_height_px = line_height_px,
+            .adjust_cell_height = adjust_cell_height,
             .sort_sets = sort_sets,
         };
         return self;
@@ -731,12 +743,18 @@ fn samePatternFace(a: ?*c.FcPattern, b: ?*c.FcPattern) bool {
     return a_index == b_index and std.mem.orderZ(u8, @ptrCast(a_file), @ptrCast(b_file)) == .eq;
 }
 
-/// Load the best match for `family` at `size_px`. `line_height_px`
-/// overrides the cell height in physical pixels; 0 uses natural metrics.
-pub fn init(alloc: std.mem.Allocator, family: [:0]const u8, size_px: u31, line_height_px: u31) Error!Font {
+/// Load the best match for `family` at `size_px` and optionally adjust its
+/// natural cell height.
+pub fn init(
+    alloc: std.mem.Allocator,
+    family: [:0]const u8,
+    size_px: u31,
+    adjust_cell_height: ?Config.MetricModifier,
+) Error!Font {
     std.debug.assert(size_px > 0);
 
-    const discovery_data = try Discovery.init(family, size_px, line_height_px);
+    const discovery_data = try Discovery.init(family, size_px, adjust_cell_height);
+    defer discovery_data.unref();
     return initWithDiscovery(alloc, discovery_data);
 }
 
@@ -767,19 +785,19 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
     }
     const primary = &faces.items[0];
     // Cell metrics: advance of a reference glyph for width, font-global
-    // ascender/descender for height, or a line-height override with the
-    // text vertically centered. ft metrics are 26.6 fixed point.
+    // ascender/descender for height. A configured adjustment changes the
+    // height and keeps the text vertically centered. ft metrics are 26.6
+    // fixed point.
     const metrics = primary.ft_face.*.size.*.metrics;
     const natural_height: u31 = @intCast((metrics.ascender - metrics.descender) >> 6);
     const ascender: u31 = @intCast(metrics.ascender >> 6);
-    const cell_height: u31 = if (discovery_data.line_height_px > 0)
-        discovery_data.line_height_px
+    const cell_height = if (discovery_data.adjust_cell_height) |modifier|
+        modifier.apply(natural_height)
     else
         natural_height;
-    // Centering offset goes negative when the override shrinks the cell.
-    const baseline: u31 = if (discovery_data.line_height_px > 0)
+    const baseline: u31 = if (discovery_data.adjust_cell_height != null)
         @intCast(std.math.clamp(
-            @as(i64, ascender) + @divTrunc(@as(i64, cell_height) - natural_height, 2),
+            @as(i64, ascender) + @divFloor(@as(i64, cell_height) - natural_height, 2),
             0,
             cell_height,
         ))
@@ -849,7 +867,7 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
             const scaled: i64 = @divTrunc(units * y_scale, 1 << 22);
             if (scaled > 0) break :thickness @intCast(scaled);
         }
-        break :thickness @max(1, cell_height / 16);
+        break :thickness @max(1, natural_height / 16);
     };
 
     // FreeType underline position: relative to baseline, +up.
@@ -857,7 +875,7 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
         const units: i64 = ft_face.*.underline_position;
         const scaled: i64 = @divTrunc(units * y_scale, 1 << 22);
         const top: i64 = baseline - scaled;
-        break :position @intCast(std.math.clamp(top, 0, cell_height - thickness));
+        break :position @intCast(std.math.clamp(top, 0, cell_height -| thickness));
     };
 
     // Center the strikethrough on lowercase text (x-height).
@@ -867,10 +885,10 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
             if (idx != 0 and c.FT_Load_Glyph(ft_face, idx, c.FT_LOAD_DEFAULT) == 0) {
                 break :ex @intCast(ft_face.*.glyph.*.metrics.horiBearingY >> 6);
             }
-            break :ex @divTrunc(@as(i64, cell_height) * 3, 10);
+            break :ex @divTrunc(@as(i64, natural_height) * 3, 10);
         };
         const top: i64 = baseline - @divTrunc(ex_height + thickness, 2);
-        break :position @intCast(std.math.clamp(top, 0, cell_height - thickness));
+        break :position @intCast(std.math.clamp(top, 0, cell_height -| thickness));
     };
 
     return .{
@@ -895,12 +913,15 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
             .strikethrough_thickness = thickness,
             .overline_position = 0,
             .overline_thickness = thickness,
+            .cursor_height = natural_height,
             .cursor_thickness = thickness,
         },
         .size_px = size_px,
         .cell_width = cell_width,
         .cell_height = cell_height,
         .baseline = baseline,
+        .neighbor_row_overhang = natural_height > cell_height,
+        .multi_row_overhang = @as(u64, natural_height) > @as(u64, cell_height) * 2,
     };
 }
 
@@ -1367,7 +1388,7 @@ fn loadFromPattern(
 
 test "load monospace font and rasterize a glyph" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     try std.testing.expect(font.cell_width > 0);
@@ -1384,7 +1405,7 @@ test "load monospace font and rasterize a glyph" {
 
 test "rasterizers share discovery but own face state" {
     const alloc = std.testing.allocator;
-    var first: Font = try .init(alloc, "monospace", 16, 0);
+    var first: Font = try .init(alloc, "monospace", 16, null);
     var first_live = true;
     defer if (first_live) first.deinit(alloc);
     var second: Font = try .initWithDiscovery(alloc, first.discovery());
@@ -1407,7 +1428,7 @@ test "styled primary faces are selected when available" {
     try std.testing.expectEqual(FaceStyle.bold_italic, FaceStyle.init(true, true));
 
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     const bold_idx = font.primary_faces[@intFromEnum(FaceStyle.bold)];
@@ -1417,7 +1438,7 @@ test "styled primary faces are selected when available" {
 
 test "embedded symbols face serves nerd font codepoints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1440,7 +1461,7 @@ test "embedded symbols face serves nerd font codepoints" {
 
 test "alpha symbols do not upscale for double-cell constraints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1460,7 +1481,7 @@ test "alpha symbols do not upscale for double-cell constraints" {
 
 test "alpha symbols fit within single-cell constraints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1479,7 +1500,7 @@ test "alpha symbols fit within single-cell constraints" {
 
 test "fallback face for a codepoint the primary lacks" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     // ASCII stays on the primary face.
@@ -1500,7 +1521,7 @@ test "fallback face for a codepoint the primary lacks" {
 
 test "color emoji fallback rasterizes as scaled BGRA" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     const cp: u21 = 0x1F600; // grinning face
@@ -1525,18 +1546,35 @@ test "color emoji fallback rasterizes as scaled BGRA" {
     try std.testing.expect(opaque_pixels > 0);
 }
 
-test "line-height override expands the cell and centers the baseline" {
+test "cell height adjustment changes metrics and centers the baseline" {
     const alloc = std.testing.allocator;
-    var natural: Font = try .init(alloc, "monospace", 16, 0);
+    var natural: Font = try .init(alloc, "monospace", 16, null);
     defer natural.deinit(alloc);
-    const doubled: u31 = natural.cell_height * 2;
-    var font: Font = try .init(alloc, "monospace", 16, doubled);
-    defer font.deinit(alloc);
 
-    try std.testing.expectEqual(doubled, font.cell_height);
-    try std.testing.expectEqual(natural.cell_width, font.cell_width);
+    var expanded: Font = try .init(alloc, "monospace", 16, .{ .percent = 100 });
+    defer expanded.deinit(alloc);
+    try std.testing.expectEqual(natural.cell_height * 2, expanded.cell_height);
+    try std.testing.expectEqual(natural.cell_width, expanded.cell_width);
     try std.testing.expectEqual(
-        natural.baseline + (doubled - natural.cell_height) / 2,
-        font.baseline,
+        natural.baseline + natural.cell_height / 2,
+        expanded.baseline,
     );
+
+    var tighter: Font = try .init(alloc, "monospace", 16, .{ .absolute = -2 });
+    defer tighter.deinit(alloc);
+    try std.testing.expectEqual(natural.cell_height - 2, tighter.cell_height);
+    try std.testing.expectEqual(natural.baseline - 1, tighter.baseline);
+
+    var odd_tighter: Font = try .init(alloc, "monospace", 16, .{ .absolute = -1 });
+    defer odd_tighter.deinit(alloc);
+    try std.testing.expectEqual(natural.cell_height - 1, odd_tighter.cell_height);
+    try std.testing.expectEqual(natural.baseline - 1, odd_tighter.baseline);
+
+    // Extreme shrinking remains valid even when natural decoration thickness
+    // exceeds the adjusted cell.
+    var minimum: Font = try .init(alloc, "monospace", 16, .{ .percent = -100 });
+    defer minimum.deinit(alloc);
+    try std.testing.expectEqual(@as(u31, 1), minimum.cell_height);
+    try std.testing.expect(minimum.baseline <= minimum.cell_height);
+    try std.testing.expect(minimum.multi_row_overhang);
 }

--- a/src/Font.zig
+++ b/src/Font.zig
@@ -101,9 +101,11 @@ pub const Discovery = struct {
     refs: std.atomic.Value(usize),
     family: [:0]u8,
     size_px: u31,
+    /// Cell height override in physical pixels; 0 uses natural metrics.
+    line_height_px: u31,
     sort_sets: [style_count]*c.FcFontSet,
 
-    fn init(family: [:0]const u8, size_px: u31) Error!*Discovery {
+    fn init(family: [:0]const u8, size_px: u31, line_height_px: u31) Error!*Discovery {
         if (c.FcInit() != c.FcTrue) return error.FontLoadFailed;
 
         var sort_sets_opt: [style_count]?*c.FcFontSet = @splat(null);
@@ -121,12 +123,12 @@ pub const Discovery = struct {
 
         const alloc = std.heap.smp_allocator;
         const family_copy = try alloc.dupeZ(u8, family);
-        errdefer alloc.free(family_copy);
         const self = try alloc.create(Discovery);
         self.* = .{
             .refs = .init(1),
             .family = family_copy,
             .size_px = size_px,
+            .line_height_px = line_height_px,
             .sort_sets = sort_sets,
         };
         return self;
@@ -729,12 +731,12 @@ fn samePatternFace(a: ?*c.FcPattern, b: ?*c.FcPattern) bool {
     return a_index == b_index and std.mem.orderZ(u8, @ptrCast(a_file), @ptrCast(b_file)) == .eq;
 }
 
-/// Load the best match for `family` (e.g. "monospace") at `size_px`.
-pub fn init(alloc: std.mem.Allocator, family: [:0]const u8, size_px: u31) Error!Font {
+/// Load the best match for `family` at `size_px`. `line_height_px`
+/// overrides the cell height in physical pixels; 0 uses natural metrics.
+pub fn init(alloc: std.mem.Allocator, family: [:0]const u8, size_px: u31, line_height_px: u31) Error!Font {
     std.debug.assert(size_px > 0);
 
-    const discovery_data = try Discovery.init(family, size_px);
-    defer discovery_data.unref();
+    const discovery_data = try Discovery.init(family, size_px, line_height_px);
     return initWithDiscovery(alloc, discovery_data);
 }
 
@@ -764,12 +766,25 @@ pub fn initWithDiscovery(alloc: std.mem.Allocator, discovery_data: *Discovery) E
         try faces.append(alloc, primary);
     }
     const primary = &faces.items[0];
-
     // Cell metrics: advance of a reference glyph for width, font-global
-    // ascender/descender for height. 26.6 fixed point.
+    // ascender/descender for height, or a line-height override with the
+    // text vertically centered. ft metrics are 26.6 fixed point.
     const metrics = primary.ft_face.*.size.*.metrics;
-    const cell_height: u31 = @intCast((metrics.ascender - metrics.descender) >> 6);
-    const baseline: u31 = @intCast(metrics.ascender >> 6);
+    const natural_height: u31 = @intCast((metrics.ascender - metrics.descender) >> 6);
+    const ascender: u31 = @intCast(metrics.ascender >> 6);
+    const cell_height: u31 = if (discovery_data.line_height_px > 0)
+        discovery_data.line_height_px
+    else
+        natural_height;
+    // Centering offset goes negative when the override shrinks the cell.
+    const baseline: u31 = if (discovery_data.line_height_px > 0)
+        @intCast(std.math.clamp(
+            @as(i64, ascender) + @divTrunc(@as(i64, cell_height) - natural_height, 2),
+            0,
+            cell_height,
+        ))
+    else
+        ascender;
     const cell_width: u31 = width: {
         const idx = c.FT_Get_Char_Index(primary.ft_face, 'M');
         if (idx != 0 and c.FT_Load_Glyph(primary.ft_face, idx, c.FT_LOAD_DEFAULT) == 0) {
@@ -1352,7 +1367,7 @@ fn loadFromPattern(
 
 test "load monospace font and rasterize a glyph" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     try std.testing.expect(font.cell_width > 0);
@@ -1369,7 +1384,7 @@ test "load monospace font and rasterize a glyph" {
 
 test "rasterizers share discovery but own face state" {
     const alloc = std.testing.allocator;
-    var first: Font = try .init(alloc, "monospace", 16);
+    var first: Font = try .init(alloc, "monospace", 16, 0);
     var first_live = true;
     defer if (first_live) first.deinit(alloc);
     var second: Font = try .initWithDiscovery(alloc, first.discovery());
@@ -1392,7 +1407,7 @@ test "styled primary faces are selected when available" {
     try std.testing.expectEqual(FaceStyle.bold_italic, FaceStyle.init(true, true));
 
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     const bold_idx = font.primary_faces[@intFromEnum(FaceStyle.bold)];
@@ -1402,7 +1417,7 @@ test "styled primary faces are selected when available" {
 
 test "embedded symbols face serves nerd font codepoints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1425,7 +1440,7 @@ test "embedded symbols face serves nerd font codepoints" {
 
 test "alpha symbols do not upscale for double-cell constraints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1445,7 +1460,7 @@ test "alpha symbols do not upscale for double-cell constraints" {
 
 test "alpha symbols fit within single-cell constraints" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     const embedded = font.embedded_face orelse return error.SkipZigTest;
@@ -1464,7 +1479,7 @@ test "alpha symbols fit within single-cell constraints" {
 
 test "fallback face for a codepoint the primary lacks" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     // ASCII stays on the primary face.
@@ -1485,7 +1500,7 @@ test "fallback face for a codepoint the primary lacks" {
 
 test "color emoji fallback rasterizes as scaled BGRA" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     const cp: u21 = 0x1F600; // grinning face
@@ -1508,4 +1523,20 @@ test "color emoji fallback rasterizes as scaled BGRA" {
         if (g.bitmap[i] != 0) opaque_pixels += 1;
     }
     try std.testing.expect(opaque_pixels > 0);
+}
+
+test "line-height override expands the cell and centers the baseline" {
+    const alloc = std.testing.allocator;
+    var natural: Font = try .init(alloc, "monospace", 16, 0);
+    defer natural.deinit(alloc);
+    const doubled: u31 = natural.cell_height * 2;
+    var font: Font = try .init(alloc, "monospace", 16, doubled);
+    defer font.deinit(alloc);
+
+    try std.testing.expectEqual(doubled, font.cell_height);
+    try std.testing.expectEqual(natural.cell_width, font.cell_width);
+    try std.testing.expectEqual(
+        natural.baseline + (doubled - natural.cell_height) / 2,
+        font.baseline,
+    );
 }

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -393,6 +393,18 @@ pub fn renderDirty(
     std.debug.assert(pixelBufferFits(pixels, self.pixelStride(width), width, height));
     self.rendered_rects.clearRetainingCapacity();
     if (state.rows == 0 or state.cols == 0) return;
+    if (self.font.multi_row_overhang) {
+        try self.render(state, pixels, width, height);
+        if (width > 0 and height > 0) {
+            try self.rendered_rects.append(self.alloc, .{
+                .x = 0,
+                .y = 0,
+                .width = width,
+                .height = height,
+            });
+        }
+        return;
+    }
     if (self.track_cell_damage) try self.measureCellDamage(state);
     try self.row_overhang.resize(self.alloc, state.rows, false);
 
@@ -404,8 +416,10 @@ pub fn renderDirty(
     for (all_dirty[0..state.rows], 0..) |dirty, y| {
         if (!dirty) continue;
         if (self.partial_cell_raster and self.cell_damage_tracker.damageForRow(y) == null) continue;
-        const expand_up = y > 0 and self.row_overhang.isSet(y);
-        const expand_down = y + 1 < state.rows and self.row_overhang.isSet(y + 1);
+        const expand_up = y > 0 and
+            (self.font.neighbor_row_overhang or self.row_overhang.isSet(y));
+        const expand_down = y + 1 < state.rows and
+            (self.font.neighbor_row_overhang or self.row_overhang.isSet(y + 1));
         const start = y - @intFromBool(expand_up);
         const end = y + 1 + @intFromBool(expand_down);
         var row = @max(start, rendered_until);
@@ -1345,18 +1359,17 @@ fn prepareRowCells(
         } else if (search_match) {
             dim_search_bg = true;
         }
-        // Focused block cursor: swap in the cursor color, invert the
-        // glyph. All other cursor shapes (and any unfocused cursor)
-        // overlay a sprite after drawing instead.
+        // Focused block cursor: recolor its glyph. Its background is painted
+        // after the cell backgrounds so it can retain the font's natural
+        // height when the cell height is adjusted. All other cursor shapes
+        // (and any unfocused cursor) overlay a sprite after drawing instead.
         if (cursor_x != null and cursor_x.? == x and
             state.cursor.visual_style == .block and self.focused)
         {
             const cell = cursorCellRgb(style, &raws[x], colors);
-            bg = self.cursorFill(colors, cell.fg, cell.bg);
             fg = self.cursorGlyph(colors, cell.fg, cell.bg);
             reverse_color_glyph = false;
             dim_search_bg = false;
-            background_uses_alpha = false;
         }
         self.fg_scratch.items[x] = fg;
         self.reverse_scratch.items[x] = reverse_color_glyph;
@@ -1404,6 +1417,37 @@ fn prepareRowCells(
         }
     }
     bg_run.flush(pixels, self.pixelStride(width), width, height, y_px, font.cell_height);
+
+    if (cursor_x) |cx| {
+        if (self.focused and state.cursor.visual_style == .block and
+            cx >= cell_range.start and cx < cell_range.end)
+        {
+            const style: vt.Style = if (raws[cx].style_id == 0) .{} else styles[cx];
+            const cell = cursorCellRgb(style, &raws[cx], colors);
+            const cursor_height = font.sprite_metrics.cursor_height;
+            const top = @as(i64, y_px) + @divTrunc(
+                @as(i64, font.cell_height) - cursor_height,
+                2,
+            );
+            const bottom = top + cursor_height;
+            const clipped_top: u31 = @intCast(std.math.clamp(top, 0, height));
+            const clipped_bottom: u31 = @intCast(std.math.clamp(bottom, 0, height));
+            if (clipped_bottom > clipped_top) {
+                const cursor_width = font.cell_width * glyph_constraints.cellSpan(raws[cx]);
+                fillRect(
+                    pixels,
+                    self.pixelStride(width),
+                    width,
+                    height,
+                    cx * font.cell_width,
+                    clipped_top,
+                    cursor_width,
+                    clipped_bottom - clipped_top,
+                    argb(self.cursorFill(colors, cell.fg, cell.bg)),
+                );
+            }
+        }
+    }
 }
 
 /// A pending run of adjacent equal-color cell backgrounds.
@@ -1812,7 +1856,7 @@ test "kitty unscaled blit honors rgba alpha" {
 
 test "kitty placement clips offsets above signed 32-bit range" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -1844,7 +1888,7 @@ test "kitty placement clips offsets above signed 32-bit range" {
 
 test "scaled kitty placement reuses cached rgba variant" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -1931,7 +1975,7 @@ test "emoji keycap grapheme selects emoji fallback face" {
     try testing.expectEqual(@as(u21, '1'), raws[0].content.codepoint.data);
     try testing.expectEqualSlices(u21, &.{ 0xFE0F, 0x20E3 }, graphemes[0]);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     const keycap_face = font.faceForCluster(alloc, &.{ '1', 0xFE0F, 0x20E3 }, .regular);
     if (keycap_face == 0) return error.SkipZigTest;
@@ -1963,7 +2007,7 @@ test "emoji presentation graphemes select emoji fallback face" {
     const alloc = testing.allocator;
     const grinning: u21 = 0x1F600;
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     const emoji_face = font.faceForCodepoint(alloc, grinning);
     if (emoji_face == 0) return error.SkipZigTest;
@@ -2032,7 +2076,7 @@ test "default emoji presentation squares select emoji fallback face" {
     const alloc = testing.allocator;
 
     const grinning: u21 = 0x1F600;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     const emoji_face = font.faceForCodepoint(alloc, grinning);
     if (emoji_face == 0) return error.SkipZigTest;
@@ -2280,7 +2324,7 @@ test "render a simple grid" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2315,7 +2359,7 @@ test "cursor splits shaping runs" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2354,7 +2398,7 @@ test "cursor colors resolve from cells unless OSC 12 is set" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{
         .cursor_color = .cell_foreground,
@@ -2382,6 +2426,34 @@ test "cursor colors resolve from cells unless OSC 12 is set" {
     try std.testing.expectEqual(argb(osc_cursor), pixels[center]);
 }
 
+test "focused block cursor keeps natural height in an expanded cell" {
+    const alloc = std.testing.allocator;
+
+    var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 1, .rows = 1 });
+    defer term.deinit(alloc);
+    var state: vt.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &term);
+
+    var font: Font = try .init(alloc, "monospace", 16, .{ .absolute = 4 });
+    defer font.deinit(alloc);
+    var renderer: Renderer = try .init(alloc, &font, .{});
+    defer renderer.deinit();
+
+    const width = font.cell_width;
+    const height = font.cell_height;
+    const pixels = try alloc.alloc(u32, @as(usize, width) * height);
+    defer alloc.free(pixels);
+    try renderer.render(&state, pixels, width, height);
+
+    const x = font.cell_width / 2;
+    try std.testing.expectEqual(argb(state.colors.background), pixels[x]);
+    try std.testing.expectEqual(
+        argb(state.colors.foreground),
+        pixels[@as(usize, 2) * width + x],
+    );
+}
+
 test "cursor fill and glyph helpers follow TerminalColor" {
     const alloc = std.testing.allocator;
     const colors: vt.RenderState.Colors = .{
@@ -2393,7 +2465,7 @@ test "cursor fill and glyph helpers follow TerminalColor" {
     const fg: vt.color.RGB = .{ .r = 10, .g = 20, .b = 30 };
     const bg: vt.color.RGB = .{ .r = 40, .g = 50, .b = 60 };
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2429,7 +2501,7 @@ test "background opacity cells controls explicit cell backgrounds" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{ .background_alpha = 128 });
     defer renderer.deinit();
@@ -2456,7 +2528,7 @@ test "render rectangular selection spans" {
     const alloc = std.testing.allocator;
     const selection_bg: vt.color.RGB = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 8, .rows = 5 });
@@ -2516,7 +2588,7 @@ test "render rectangular selection spans" {
 test "render kitty image placement" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2564,7 +2636,7 @@ test "render kitty image placement" {
 test "kitty placement collection uses the current animation frame" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2591,7 +2663,7 @@ test "kitty placement collection uses the current animation frame" {
 test "render kitty unicode placeholder placement" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2641,7 +2713,7 @@ test "dirty row render matches full render" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2666,6 +2738,36 @@ test "dirty row render matches full render" {
     try std.testing.expectEqualSlices(u32, full_pixels, dirty_pixels);
 }
 
+test "extreme cell height shrinking falls back to full damage" {
+    const alloc = std.testing.allocator;
+
+    var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 2, .rows = 2 });
+    defer term.deinit(alloc);
+    var state: vt.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &term);
+
+    var font: Font = try .init(alloc, "monospace", 16, .{ .percent = -100 });
+    defer font.deinit(alloc);
+    try std.testing.expect(font.multi_row_overhang);
+    var renderer: Renderer = try .init(alloc, &font, .{});
+    defer renderer.deinit();
+
+    const width: u31 = font.cell_width * 2;
+    const height: u31 = font.cell_height * 2;
+    const pixels = try alloc.alloc(u32, @as(usize, width) * height);
+    defer alloc.free(pixels);
+    try renderer.renderDirty(&state, pixels, width, height);
+
+    try std.testing.expectEqual(@as(usize, 1), renderer.rendered_rects.items.len);
+    try std.testing.expectEqual(PixelRect{
+        .x = 0,
+        .y = 0,
+        .width = width,
+        .height = height,
+    }, renderer.rendered_rects.items[0]);
+}
+
 test "cell damage render matches full render for sparse row churn" {
     const alloc = std.testing.allocator;
     const cols = 48;
@@ -2678,7 +2780,7 @@ test "cell damage render matches full render for sparse row churn" {
 
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{
         .track_cell_damage = true,
@@ -2730,7 +2832,7 @@ test "cell damage repairs rotating stale buffers" {
     defer stream.deinit();
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{});
     defer partial.deinit();
@@ -2805,7 +2907,7 @@ test "cell damage clips an adjacent text run to the cleared interval" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{
         .track_cell_damage = true,
@@ -2856,7 +2958,7 @@ test "cell damage redraws symbol ink spilling into the interval" {
         glyph_constraints.constraintWidth(state.row_data.get(0).cells.items(.raw), 5, cols),
     );
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{});
     defer partial.deinit();
@@ -2899,7 +3001,7 @@ test "scroll invalidates newly exposed cell fingerprints" {
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
     try state.update(alloc, &term);
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2942,7 +3044,7 @@ test "cell damage repaints dirty rows after terminal colors change" {
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
     try state.update(alloc, &term);
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2996,7 +3098,7 @@ test "search match uses its own highlight background" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -3035,7 +3137,7 @@ test "unselected search match tints its existing background" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -1812,7 +1812,7 @@ test "kitty unscaled blit honors rgba alpha" {
 
 test "kitty placement clips offsets above signed 32-bit range" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -1844,7 +1844,7 @@ test "kitty placement clips offsets above signed 32-bit range" {
 
 test "scaled kitty placement reuses cached rgba variant" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -1931,7 +1931,7 @@ test "emoji keycap grapheme selects emoji fallback face" {
     try testing.expectEqual(@as(u21, '1'), raws[0].content.codepoint.data);
     try testing.expectEqualSlices(u21, &.{ 0xFE0F, 0x20E3 }, graphemes[0]);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     const keycap_face = font.faceForCluster(alloc, &.{ '1', 0xFE0F, 0x20E3 }, .regular);
     if (keycap_face == 0) return error.SkipZigTest;
@@ -1963,7 +1963,7 @@ test "emoji presentation graphemes select emoji fallback face" {
     const alloc = testing.allocator;
     const grinning: u21 = 0x1F600;
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     const emoji_face = font.faceForCodepoint(alloc, grinning);
     if (emoji_face == 0) return error.SkipZigTest;
@@ -2032,7 +2032,7 @@ test "default emoji presentation squares select emoji fallback face" {
     const alloc = testing.allocator;
 
     const grinning: u21 = 0x1F600;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     const emoji_face = font.faceForCodepoint(alloc, grinning);
     if (emoji_face == 0) return error.SkipZigTest;
@@ -2280,7 +2280,7 @@ test "render a simple grid" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2315,7 +2315,7 @@ test "cursor splits shaping runs" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2354,7 +2354,7 @@ test "cursor colors resolve from cells unless OSC 12 is set" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{
         .cursor_color = .cell_foreground,
@@ -2393,7 +2393,7 @@ test "cursor fill and glyph helpers follow TerminalColor" {
     const fg: vt.color.RGB = .{ .r = 10, .g = 20, .b = 30 };
     const bg: vt.color.RGB = .{ .r = 40, .g = 50, .b = 60 };
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2429,7 +2429,7 @@ test "background opacity cells controls explicit cell backgrounds" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{ .background_alpha = 128 });
     defer renderer.deinit();
@@ -2456,7 +2456,7 @@ test "render rectangular selection spans" {
     const alloc = std.testing.allocator;
     const selection_bg: vt.color.RGB = .{ .r = 0x12, .g = 0x34, .b = 0x56 };
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 8, .rows = 5 });
@@ -2516,7 +2516,7 @@ test "render rectangular selection spans" {
 test "render kitty image placement" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2564,7 +2564,7 @@ test "render kitty image placement" {
 test "kitty placement collection uses the current animation frame" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2591,7 +2591,7 @@ test "kitty placement collection uses the current animation frame" {
 test "render kitty unicode placeholder placement" {
     const alloc = std.testing.allocator;
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
 
     var term: vt.Terminal = try .init(std.testing.io, alloc, .{ .cols = 4, .rows = 2 });
@@ -2641,7 +2641,7 @@ test "dirty row render matches full render" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2678,7 +2678,7 @@ test "cell damage render matches full render for sparse row churn" {
 
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{
         .track_cell_damage = true,
@@ -2730,7 +2730,7 @@ test "cell damage repairs rotating stale buffers" {
     defer stream.deinit();
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{});
     defer partial.deinit();
@@ -2805,7 +2805,7 @@ test "cell damage clips an adjacent text run to the cleared interval" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{
         .track_cell_damage = true,
@@ -2856,7 +2856,7 @@ test "cell damage redraws symbol ink spilling into the interval" {
         glyph_constraints.constraintWidth(state.row_data.get(0).cells.items(.raw), 5, cols),
     );
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var partial: Renderer = try .init(alloc, &font, .{});
     defer partial.deinit();
@@ -2899,7 +2899,7 @@ test "scroll invalidates newly exposed cell fingerprints" {
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
     try state.update(alloc, &term);
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2942,7 +2942,7 @@ test "cell damage repaints dirty rows after terminal colors change" {
     var state: vt.RenderState = .empty;
     defer state.deinit(alloc);
     try state.update(alloc, &term);
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -2996,7 +2996,7 @@ test "search match uses its own highlight background" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
@@ -3035,7 +3035,7 @@ test "unselected search match tints its existing background" {
     defer state.deinit(alloc);
     try state.update(alloc, &term);
 
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();

--- a/src/TextShaper.zig
+++ b/src/TextShaper.zig
@@ -292,7 +292,7 @@ fn shapeClusterWith(
 
 test "cache separates identical runs by fallback style" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var shaper: TextShaper = try .init(alloc, &font);
     defer shaper.deinit();

--- a/src/TextShaper.zig
+++ b/src/TextShaper.zig
@@ -292,7 +292,7 @@ fn shapeClusterWith(
 
 test "cache separates identical runs by fallback style" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var shaper: TextShaper = try .init(alloc, &font);
     defer shaper.deinit();

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -27,7 +27,7 @@ pub fn run(init: std.process.Init) !void {
         alloc,
         config.font_family,
         font_size_px,
-        config.lineHeightPixels(font_size_px, 120),
+        config.adjust_cell_height,
     );
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -23,7 +23,12 @@ pub fn run(init: std.process.Init) !void {
     try config.resolveThemes(init.io, arena, init.minimal.environ);
 
     const font_size_px = Config.fontSizePixels(config.font_size, 120);
-    var font: Font = try .init(alloc, config.font_family, font_size_px);
+    var font: Font = try .init(
+        alloc,
+        config.font_family,
+        font_size_px,
+        config.lineHeightPixels(font_size_px, 120),
+    );
     defer font.deinit(alloc);
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();

--- a/src/kitty_graphics.zig
+++ b/src/kitty_graphics.zig
@@ -556,7 +556,7 @@ test "kitty placement dimensions reject unrepresentable geometry" {
 
 test "collect relative kitty placement rooted at a pin" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var terminal: vt.Terminal = try .init(std.testing.io, alloc, .{ .rows = 10, .cols = 10 });
     defer terminal.deinit(alloc);
@@ -604,7 +604,7 @@ test "collect relative kitty placement rooted at a pin" {
 
 test "collect relative kitty placement rooted at virtual placeholders" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16, 0);
+    var font: Font = try .init(alloc, "monospace", 16, null);
     defer font.deinit(alloc);
     var terminal: vt.Terminal = try .init(std.testing.io, alloc, .{ .rows = 5, .cols = 5 });
     defer terminal.deinit(alloc);

--- a/src/kitty_graphics.zig
+++ b/src/kitty_graphics.zig
@@ -556,7 +556,7 @@ test "kitty placement dimensions reject unrepresentable geometry" {
 
 test "collect relative kitty placement rooted at a pin" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var terminal: vt.Terminal = try .init(std.testing.io, alloc, .{ .rows = 10, .cols = 10 });
     defer terminal.deinit(alloc);
@@ -604,7 +604,7 @@ test "collect relative kitty placement rooted at a pin" {
 
 test "collect relative kitty placement rooted at virtual placeholders" {
     const alloc = std.testing.allocator;
-    var font: Font = try .init(alloc, "monospace", 16);
+    var font: Font = try .init(alloc, "monospace", 16, 0);
     defer font.deinit(alloc);
     var terminal: vt.Terminal = try .init(std.testing.io, alloc, .{ .rows = 5, .cols = 5 });
     defer terminal.deinit(alloc);

--- a/src/sprite.zig
+++ b/src/sprite.zig
@@ -148,7 +148,7 @@ pub fn render(
 ) !Glyph {
     std.debug.assert(cell_span >= 1);
     const draw = getDrawFn(cp) orelse unreachable; // covers() gates this
-    return renderWith(alloc, draw, cp, metrics, baseline, cell_span);
+    return renderWith(alloc, draw, cp, metrics, baseline, cell_span, metrics.cell_height);
 }
 
 /// Render a text decoration sprite.
@@ -166,6 +166,10 @@ pub fn renderDecoration(
             metrics,
             baseline,
             1,
+            switch (k) {
+                .cursor_bar, .cursor_hollow_rect => metrics.cursor_height,
+                else => metrics.cell_height,
+            },
         ),
     };
 }
@@ -177,25 +181,32 @@ fn renderWith(
     metrics: Metrics,
     baseline: u31,
     cell_span: u2,
+    draw_height: u32,
 ) !Glyph {
     var draw_metrics = metrics;
     draw_metrics.cell_width *= cell_span;
     const pad_x = metrics.cell_width / 4;
-    const pad_y = metrics.cell_height / 4;
+    const pad_y = draw_height / 4;
     var canvas: canvas_mod.Canvas = try .init(
         alloc,
         draw_metrics.cell_width,
-        metrics.cell_height,
+        draw_height,
         pad_x,
         pad_y,
     );
     defer canvas.deinit();
 
-    try draw(cp, &canvas, draw_metrics.cell_width, metrics.cell_height, draw_metrics);
+    try draw(cp, &canvas, draw_metrics.cell_width, draw_height, draw_metrics);
 
     const bitmap = try canvas.toBitmap(alloc);
-    // Bitmap top relative to the cell top: clip_top - pad_y.
-    const top: i32 = @as(i32, @intCast(bitmap.clip_top)) - @as(i32, @intCast(pad_y));
+    // Full-height cursors keep their natural height and remain centered when
+    // cell height is adjusted.
+    const center_offset = @divTrunc(
+        @as(i32, @intCast(metrics.cell_height)) - @as(i32, @intCast(draw_height)),
+        2,
+    );
+    const top: i32 = @as(i32, @intCast(bitmap.clip_top)) -
+        @as(i32, @intCast(pad_y)) + center_offset;
     return .{
         .bitmap = bitmap.data,
         .width = @intCast(bitmap.width),
@@ -215,6 +226,7 @@ const test_metrics: Metrics = .{
     .strikethrough_thickness = 1,
     .overline_position = 0,
     .overline_thickness = 1,
+    .cursor_height = 20,
     .cursor_thickness = 1,
 };
 
@@ -281,6 +293,7 @@ test "render box drawing sprites" {
         .cell_width = 11,
         .cell_height = 23,
         .box_thickness = 1,
+        .cursor_height = 23,
     };
     inline for (&.{ 0x1FB98, 0x1FB99, 0x1CC1F, 0x1CC20 }) |cp| {
         const g = try render(alloc, cp, odd_metrics, 17, 1);
@@ -305,4 +318,13 @@ test "render decorations" {
         for (g.bitmap) |px| sum += px;
         try std.testing.expect(sum > 0);
     }
+
+    var adjusted = test_metrics;
+    adjusted.cell_height = 10;
+    const cursor = try renderDecoration(alloc, .cursor_bar, adjusted, 8);
+    defer alloc.free(cursor.bitmap);
+    try std.testing.expectEqual(@as(u31, 20), cursor.height);
+    // The natural-height cursor is centered five pixels above the shorter
+    // adjusted cell.
+    try std.testing.expectEqual(@as(i32, 13), cursor.bearing_y);
 }

--- a/src/sprite/metrics.zig
+++ b/src/sprite/metrics.zig
@@ -16,5 +16,6 @@ pub const Metrics = struct {
     overline_position: i32 = 0,
     overline_thickness: u32 = 1,
 
+    cursor_height: u32,
     cursor_thickness: u32 = 1,
 };


### PR DESCRIPTION
This adds `line-height` to the config, the same idea as foot's: an absolute height in points (`line-height = 16` or `16pt`) or logical pixels (`16px`) that replaces the cell height derived from font metrics. Unset stays exactly as before. Text is centered vertically in the taller/shorter cell, and zooming the font scales the line height by the same ratio, so `Ctrl++` keeps your proportions.

The resolved pixel height rides along on `Font.Discovery`, so the async raster worker always agrees with the main renderer on cell metrics, and the existing discovery-identity check in `configuredFor()` is enough to invalidate it.

Two small deliberate deviations from foot: odd leading truncates instead of rounding (at most half a pixel at the usual values), and the baseline clamps to the cell instead of going negative on extreme undersizing.

Tests cover the pt/px parsing, the zoom scaling, and the metric changes. One pre-existing failure on my machine (`alpha symbols do not upscale...`), unchanged from main.