### PR TITLE
set COLORTERM=truecolor in child environment

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -349,10 +349,12 @@ fn buildEnvp(
         const e = entry orelse continue;
         const value = std.mem.span(e);
         if (std.mem.startsWith(u8, value, "TERM=")) continue;
+        if (std.mem.startsWith(u8, value, "COLORTERM=")) continue;
         if (std.mem.startsWith(u8, value, "TERMINFO=")) has_terminfo = true;
         try list.append(arena, e);
     }
     try list.append(arena, "TERM=monstar");
+    try list.append(arena, "COLORTERM=truecolor");
     if (!has_terminfo) {
         var exe_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
         if (std.process.executableDirPath(io, &exe_dir_buf)) |len| {


### PR DESCRIPTION
The renderer and terminfo already support 24-bit color (setrgbf/setrgbb), but the child environment never advertised it. Child apps that probe COLORTERM (vim, pi, many ncurses apps) fell back to 256-color approximation. Match Ghostty, which sets COLORTERM=truecolor.