### PR TITLE
keyboard: add configurable line scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Other settings:
   motion after release (default `true`).
 - **copy-highlight-duration** — Post-copy selection flash in milliseconds;
   `0` disables the flash (default `200`).
+- **scroll-line-up-key / scroll-line-down-key** — Shortcuts that move the
+  scrollback viewport by one line. The defaults are `shift+up` and
+  `shift+down`. Combine `shift`, `ctrl`, `alt`, or `super` with one ASCII key
+  or a named navigation key.
 - **background / foreground / cursor-color / cursor-text** — Terminal colors
   as `#RRGGBB` or `RRGGBB`; explicit colors override the theme.
   `cursor-color` and `cursor-text` also accept `cell-foreground` and
@@ -159,6 +163,7 @@ settings apply to new windows.
 | `Ctrl+Shift+F` | Search scrollback |
 | `Ctrl+Shift+N` | Open a new window in the current directory |
 | `Ctrl+Shift+,` | Reload configuration |
+| `Shift+Up` / `Shift+Down` | Scroll up / down one line |
 | `Shift+PageUp` / `Shift+PageDown` | Scroll back / forward one page |
 | `Shift+Home` / `Shift+End` | Scroll to the top / bottom of scrollback |
 | `Ctrl++` / `Ctrl+=` / `Ctrl+-` | Adjust the font size |

--- a/README.md
+++ b/README.md
@@ -133,10 +133,8 @@ Other settings:
   motion after release (default `true`).
 - **copy-highlight-duration** — Post-copy selection flash in milliseconds;
   `0` disables the flash (default `200`).
-- **scroll-line-up-key / scroll-line-down-key** — Shortcuts that move the
-  scrollback viewport by one line. The defaults are `shift+up` and
-  `shift+down`. Combine `shift`, `ctrl`, `alt`, or `super` with one ASCII key
-  or a named navigation key.
+- **keybind** — Repeatable Ghostty-style `trigger=action` bindings for line
+  scrolling. See [Keybindings](#keybindings) below.
 - **background / foreground / cursor-color / cursor-text** — Terminal colors
   as `#RRGGBB` or `RRGGBB`; explicit colors override the theme.
   `cursor-color` and `cursor-text` also accept `cell-foreground` and
@@ -156,6 +154,37 @@ Visual and interaction settings apply immediately. Process and storage
 settings apply to new windows.
 
 ## Keybindings
+
+Configure line scrolling with repeatable `keybind` entries:
+
+```conf
+# Default line-scrolling bindings:
+keybind = shift+up=scroll_page_lines:-1
+keybind = shift+down=scroll_page_lines:1
+# Additional shortcuts, with independent line counts:
+keybind = ctrl+shift+k=scroll_page_lines:-5
+keybind = alt+j=scroll_page_lines:5
+# Remove a default shortcut:
+keybind = shift+up=unbind
+```
+
+Negative counts scroll up; positive counts scroll down. Counts range from
+`-32768` to `32767`. Multiple triggers can invoke the same action; repeating a
+trigger replaces its previous binding. Invalid entries leave previous bindings
+unchanged. Bindings reload with the configuration.
+
+Triggers combine lowercase `shift`, `ctrl` (`control`), `alt` (`opt`, `option`),
+or `super` (`cmd`, `command`) with one key. A single Unicode character such as
+`k` or `ö` follows the keyboard layout; names such as `KeyK`, `arrow_up`,
+`PageUp`, or `equal` select physical keys. `up`, `down`, `left`, and `right`
+are also accepted. Modifiers match exactly (ignoring Caps Lock and Num Lock).
+Include Shift when it is held to produce punctuation, for example
+`keybind = ctrl+shift++=scroll_page_lines:-5` on a US keyboard.
+
+Configured bindings take precedence over fixed shortcuts below; `unbind`
+passes the key to the application instead. Only `scroll_page_lines` and
+`unbind` are currently supported actions. Ghostty sequences, binding flags,
+and other actions are not yet supported. Search mode retains its own controls.
 
 | Shortcut | Action |
 | --- | --- |

--- a/dist/monstar.1
+++ b/dist/monstar.1
@@ -199,6 +199,9 @@ Jump to the next OSC 133 prompt.
 .B Ctrl+Shift+Z
 Jump to the previous OSC 133 prompt.
 .TP
+.BR Shift+Up " or " Shift+Down
+Scroll up or down by one terminal line.
+.TP
 .BR Shift+PageUp " or " Shift+PageDown
 Scroll backward or forward by one terminal page.
 .TP

--- a/dist/monstar.5
+++ b/dist/monstar.5
@@ -194,6 +194,34 @@ The defaults are
 and
 .BR discrete:3 .
 .TP
+.BI scroll-line-up-key " = shortcut"
+Set the shortcut that scrolls up by one terminal line.
+The default is
+.BR shift+up .
+.TP
+.BI scroll-line-down-key " = shortcut"
+Set the shortcut that scrolls down by one terminal line.
+The default is
+.BR shift+down .
+.PP
+A shortcut accepts
+.BR shift ,
+.BR ctrl ,
+.BR alt ,
+or
+.B super
+modifiers and one key.
+Use one ASCII key or a named navigation key:
+.BR up ,
+.BR down ,
+.BR left ,
+.BR right ,
+.BR page-up ,
+.BR page-down ,
+.BR home ,
+or
+.BR end .
+.TP
 .BI scrollback-limit " = bytes"
 Set the terminal page-storage limit, including the active screen.
 The default is 50000000 bytes.

--- a/dist/monstar.5
+++ b/dist/monstar.5
@@ -194,33 +194,61 @@ The defaults are
 and
 .BR discrete:3 .
 .TP
-.BI scroll-line-up-key " = shortcut"
-Set the shortcut that scrolls up by one terminal line.
-The default is
-.BR shift+up .
-.TP
-.BI scroll-line-down-key " = shortcut"
-Set the shortcut that scrolls down by one terminal line.
-The default is
-.BR shift+down .
+.BI keybind " = trigger=action"
+Add or replace a Ghostty-style single-key binding. Repeat this setting to bind
+multiple triggers. Repeating the same trigger replaces its previous binding;
+an invalid entry leaves previous bindings unchanged.
+.B scroll_page_lines:N
+scrolls by N terminal lines: negative values scroll up, positive values scroll
+down, and zero consumes the key without moving. N must be between -32768 and
+32767.
+.B unbind
+removes a shortcut and passes its input to the application.
 .PP
-A shortcut accepts
+The default line-scrolling bindings are:
+.nf
+keybind = shift+up=scroll_page_lines:-1
+keybind = shift+down=scroll_page_lines:1
+.fi
+.PP
+For example, add a five-line shortcut and remove the default up shortcut:
+.nf
+keybind = ctrl+shift+k=scroll_page_lines:-5
+keybind = shift+up=unbind
+.fi
+.PP
+Triggers accept lowercase
 .BR shift ,
-.BR ctrl ,
-.BR alt ,
+.B ctrl
+(alias
+.BR control ),
+.B alt
+(aliases
+.BR opt ", " option ),
 or
 .B super
-modifiers and one key.
-Use one ASCII key or a named navigation key:
-.BR up ,
-.BR down ,
-.BR left ,
-.BR right ,
-.BR page-up ,
-.BR page-down ,
-.BR home ,
-or
-.BR end .
+(aliases
+.BR cmd ", " command )
+with one key. A single Unicode character follows the keyboard layout;
+key names such as
+.BR KeyK ", " arrow_up ", " PageUp ", " equal
+select physical keys. The aliases
+.BR up ", " down ", " left ", " right
+are also accepted. Modifiers match exactly, ignoring lock keys and modifier
+sides. Include Shift when held to produce punctuation; on a US keyboard,
+.B ctrl+shift++=scroll_page_lines:-5
+binds Ctrl+Shift+Plus. Use
+.B ctrl+==scroll_page_lines:-5
+to bind Ctrl+Equals.
+.PP
+Configured bindings take priority over fixed shortcuts and apply immediately
+on configuration reload. Scroll actions pass through on the alternate screen.
+Search mode retains its own controls. Only
+.B scroll_page_lines
+and
+.B unbind
+actions are supported; sequences, binding flags and other Ghostty actions are
+not supported.
 .TP
 .BI scrollback-limit " = bytes"
 Set the terminal page-storage limit, including the active screen.

--- a/src/App.zig
+++ b/src/App.zig
@@ -5009,6 +5009,8 @@ fn handleSearchKey(self: *App, event: vt.input.KeyEvent) void {
 }
 
 const ScrollbackKeyAction = enum {
+    line_up,
+    line_down,
     page_up,
     page_down,
     top,
@@ -5016,12 +5018,15 @@ const ScrollbackKeyAction = enum {
 };
 
 fn scrollbackKeyAction(
+    config: *const Config,
     active_screen: vt.ScreenSet.Key,
     event: vt.input.KeyEvent,
 ) ?ScrollbackKeyAction {
     // Like foot, leave scrollback shortcuts to full-screen applications.
-    if (active_screen != .primary or !event.mods.shift or
-        event.mods.ctrl or event.mods.alt or event.mods.super) return null;
+    if (active_screen != .primary) return null;
+    if (config.scroll_line_up_key.matches(event)) return .line_up;
+    if (config.scroll_line_down_key.matches(event)) return .line_down;
+    if (!event.mods.shift or event.mods.ctrl or event.mods.alt or event.mods.super) return null;
 
     return switch (event.key) {
         .page_up => .page_up,
@@ -5033,13 +5038,15 @@ fn scrollbackKeyAction(
 }
 
 fn handleScrollbackKey(self: *App, event: vt.input.KeyEvent) bool {
-    const scroll = scrollbackKeyAction(self.term.screens.active_key, event) orelse return false;
+    const scroll = scrollbackKeyAction(&self.config, self.term.screens.active_key, event) orelse return false;
     // Consume the matching release too, but move only on press/repeat.
     if (event.action == .release) return true;
 
     self.stopFling();
     const rows: isize = @intCast(self.term.rows);
     switch (scroll) {
+        .line_up => self.term.screens.active.pages.scroll(.{ .delta_row = -1 }),
+        .line_down => self.term.screens.active.pages.scroll(.{ .delta_row = 1 }),
         .page_up => self.term.screens.active.pages.scroll(.{ .delta_row = -rows }),
         .page_down => self.term.screens.active.pages.scroll(.{ .delta_row = rows }),
         .top => self.term.screens.active.pages.scroll(.top),
@@ -6069,39 +6076,63 @@ test "search backspace removes one UTF-8 codepoint" {
     try std.testing.expect(!truncateLastUtf8(&query));
 }
 
-test "scrollback keys require shift on the primary screen" {
+test "scrollback keys require supported modifiers on the primary screen" {
+    var config: Config = .{};
     const shifted: vt.input.KeyMods = .{ .shift = true };
+    const ctrl_shifted: vt.input.KeyMods = .{ .shift = true, .ctrl = true };
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.line_up,
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = shifted }).?,
+    );
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.line_down,
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_down, .mods = shifted }).?,
+    );
     try std.testing.expectEqual(
         ScrollbackKeyAction.page_up,
-        scrollbackKeyAction(.primary, .{ .key = .page_up, .mods = shifted }).?,
+        scrollbackKeyAction(&config, .primary, .{ .key = .page_up, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
         ScrollbackKeyAction.page_down,
-        scrollbackKeyAction(.primary, .{ .key = .page_down, .mods = shifted }).?,
+        scrollbackKeyAction(&config, .primary, .{ .key = .page_down, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
         ScrollbackKeyAction.top,
-        scrollbackKeyAction(.primary, .{ .key = .home, .mods = shifted }).?,
+        scrollbackKeyAction(&config, .primary, .{ .key = .home, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
         ScrollbackKeyAction.bottom,
-        scrollbackKeyAction(.primary, .{ .key = .end, .mods = shifted }).?,
+        scrollbackKeyAction(&config, .primary, .{ .key = .end, .mods = shifted }).?,
     );
 
     try std.testing.expectEqual(
         null,
-        scrollbackKeyAction(.alternate, .{ .key = .page_up, .mods = shifted }),
+        scrollbackKeyAction(&config, .alternate, .{ .key = .arrow_up, .mods = shifted }),
     );
     try std.testing.expectEqual(
         null,
-        scrollbackKeyAction(.primary, .{ .key = .page_up }),
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = ctrl_shifted }),
     );
     try std.testing.expectEqual(
         null,
-        scrollbackKeyAction(.primary, .{
+        scrollbackKeyAction(&config, .primary, .{ .key = .page_up }),
+    );
+    try std.testing.expectEqual(
+        null,
+        scrollbackKeyAction(&config, .primary, .{
             .key = .page_up,
-            .mods = .{ .shift = true, .ctrl = true },
+            .mods = ctrl_shifted,
         }),
+    );
+
+    config.scroll_line_up_key.mods.ctrl = true;
+    try std.testing.expectEqual(
+        ScrollbackKeyAction.line_up,
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = ctrl_shifted }).?,
+    );
+    try std.testing.expectEqual(
+        null,
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = shifted }),
     );
 }
 

--- a/src/App.zig
+++ b/src/App.zig
@@ -19,6 +19,7 @@ const vt = @import("ghostty-vt");
 const Clipboard = @import("Clipboard.zig");
 const KittyClipboard = @import("KittyClipboard.zig");
 const Config = @import("Config.zig");
+const keybind = @import("keybind.zig");
 const Font = @import("Font.zig");
 const Keyboard = @import("Keyboard.zig");
 const Link = @import("Link.zig");
@@ -5008,13 +5009,13 @@ fn handleSearchKey(self: *App, event: vt.input.KeyEvent) void {
     }
 }
 
-const ScrollbackKeyAction = enum {
-    line_up,
-    line_down,
+const ScrollbackKeyAction = union(enum) {
+    lines: isize,
     page_up,
     page_down,
     top,
     bottom,
+    passthrough,
 };
 
 fn scrollbackKeyAction(
@@ -5022,10 +5023,16 @@ fn scrollbackKeyAction(
     active_screen: vt.ScreenSet.Key,
     event: vt.input.KeyEvent,
 ) ?ScrollbackKeyAction {
-    // Like foot, leave scrollback shortcuts to full-screen applications.
+    if (keybind.getEvent(config.keybinds.items, event)) |action| {
+        // Explicit bindings override fixed shortcuts even when unbound or
+        // passed through to an alternate-screen application.
+        return switch (action) {
+            .unbind => .passthrough,
+            .scroll_page_lines => |lines| if (active_screen == .primary) .{ .lines = lines } else .passthrough,
+        };
+    }
+    // Leave scrollback shortcuts to full-screen applications.
     if (active_screen != .primary) return null;
-    if (config.scroll_line_up_key.matches(event)) return .line_up;
-    if (config.scroll_line_down_key.matches(event)) return .line_down;
     if (!event.mods.shift or event.mods.ctrl or event.mods.alt or event.mods.super) return null;
 
     return switch (event.key) {
@@ -5037,25 +5044,24 @@ fn scrollbackKeyAction(
     };
 }
 
-fn handleScrollbackKey(self: *App, event: vt.input.KeyEvent) bool {
-    const scroll = scrollbackKeyAction(&self.config, self.term.screens.active_key, event) orelse return false;
+fn handleScrollbackKey(self: *App, event: vt.input.KeyEvent, scroll: ScrollbackKeyAction) void {
+    std.debug.assert(scroll != .passthrough);
     // Consume the matching release too, but move only on press/repeat.
-    if (event.action == .release) return true;
+    if (event.action == .release) return;
 
     self.stopFling();
     const rows: isize = @intCast(self.term.rows);
     switch (scroll) {
-        .line_up => self.term.screens.active.pages.scroll(.{ .delta_row = -1 }),
-        .line_down => self.term.screens.active.pages.scroll(.{ .delta_row = 1 }),
+        .lines => |lines| self.term.screens.active.pages.scroll(.{ .delta_row = lines }),
         .page_up => self.term.screens.active.pages.scroll(.{ .delta_row = -rows }),
         .page_down => self.term.screens.active.pages.scroll(.{ .delta_row = rows }),
         .top => self.term.screens.active.pages.scroll(.top),
         .bottom => self.term.screens.active.pages.scroll(.active),
+        .passthrough => unreachable,
     }
     self.revealScrollbar();
     self.needs_redraw = true;
     self.syncHoveredLink(true);
-    return true;
 }
 
 fn onKey(self: *App, evdev_keycode: u32, action: vt.input.KeyAction) void {
@@ -5064,32 +5070,34 @@ fn onKey(self: *App, evdev_keycode: u32, action: vt.input.KeyAction) void {
 
     if (self.search != null) return self.handleSearchKey(event);
 
-    // Shift is only allowed on `=` (for `Ctrl++`); ctrl+_ and ctrl+) belong to the application.
-    if (action == .press and event.mods.ctrl) {
-        switch (event.unshifted_codepoint) {
-            '=' => return self.adjustRuntimeFontSize(1),
-            '-' => if (!event.mods.shift) return self.adjustRuntimeFontSize(-1),
-            '0' => if (!event.mods.shift) return self.resetRuntimeFontSize(),
-            else => {},
+    if (scrollbackKeyAction(&self.config, self.term.screens.active_key, event)) |scroll| {
+        if (scroll != .passthrough) return self.handleScrollbackKey(event, scroll);
+    } else {
+        // Shift is only allowed on `=` (for `Ctrl++`); ctrl+_ and ctrl+) belong to the application.
+        if (action == .press and event.mods.ctrl) {
+            switch (event.unshifted_codepoint) {
+                '=' => return self.adjustRuntimeFontSize(1),
+                '-' => if (!event.mods.shift) return self.adjustRuntimeFontSize(-1),
+                '0' => if (!event.mods.shift) return self.resetRuntimeFontSize(),
+                else => {},
+            }
+        }
+
+        // Copy/paste bindings take priority over the application.
+        if (action == .press and event.mods.ctrl and event.mods.shift) {
+            switch (event.unshifted_codepoint) {
+                'c' => return self.copyToClipboard(),
+                'f' => return self.startSearch(),
+                'g' => return self.pipeCommandOutput(),
+                'n' => return self.spawnNewWindow(),
+                'v' => return self.beginPaste(.clipboard),
+                'x' => return self.jumpPrompt(1),
+                'z' => return self.jumpPrompt(-1),
+                ',' => return self.reloadConfig(),
+                else => {},
+            }
         }
     }
-
-    // Copy/paste bindings take priority over the application.
-    if (action == .press and event.mods.ctrl and event.mods.shift) {
-        switch (event.unshifted_codepoint) {
-            'c' => return self.copyToClipboard(),
-            'f' => return self.startSearch(),
-            'g' => return self.pipeCommandOutput(),
-            'n' => return self.spawnNewWindow(),
-            'v' => return self.beginPaste(.clipboard),
-            'x' => return self.jumpPrompt(1),
-            'z' => return self.jumpPrompt(-1),
-            ',' => return self.reloadConfig(),
-            else => {},
-        }
-    }
-
-    if (self.handleScrollbackKey(event)) return;
 
     const wrote = self.encodeAndWriteKey(event);
 
@@ -6078,14 +6086,15 @@ test "search backspace removes one UTF-8 codepoint" {
 
 test "scrollback keys require supported modifiers on the primary screen" {
     var config: Config = .{};
+    defer config.keybinds.deinit(std.testing.allocator);
     const shifted: vt.input.KeyMods = .{ .shift = true };
     const ctrl_shifted: vt.input.KeyMods = .{ .shift = true, .ctrl = true };
     try std.testing.expectEqual(
-        ScrollbackKeyAction.line_up,
+        ScrollbackKeyAction{ .lines = -1 },
         scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
-        ScrollbackKeyAction.line_down,
+        ScrollbackKeyAction{ .lines = 1 },
         scrollbackKeyAction(&config, .primary, .{ .key = .arrow_down, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
@@ -6106,8 +6115,8 @@ test "scrollback keys require supported modifiers on the primary screen" {
     );
 
     try std.testing.expectEqual(
-        null,
-        scrollbackKeyAction(&config, .alternate, .{ .key = .arrow_up, .mods = shifted }),
+        ScrollbackKeyAction.passthrough,
+        scrollbackKeyAction(&config, .alternate, .{ .key = .arrow_up, .mods = shifted }).?,
     );
     try std.testing.expectEqual(
         null,
@@ -6125,15 +6134,37 @@ test "scrollback keys require supported modifiers on the primary screen" {
         }),
     );
 
-    config.scroll_line_up_key.mods.ctrl = true;
+    try config.set(std.testing.allocator, "keybind", "ctrl+shift+up=scroll_page_lines:-5");
+    try config.set(std.testing.allocator, "keybind", "shift+up=unbind");
     try std.testing.expectEqual(
-        ScrollbackKeyAction.line_up,
+        ScrollbackKeyAction{ .lines = -5 },
         scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = ctrl_shifted }).?,
     );
     try std.testing.expectEqual(
-        null,
-        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = shifted }),
+        ScrollbackKeyAction.passthrough,
+        scrollbackKeyAction(&config, .primary, .{ .key = .arrow_up, .mods = shifted }).?,
     );
+}
+
+test "custom scrolling overrides fixed chords and passes through on the alternate screen" {
+    var config: Config = .{};
+    defer config.keybinds.deinit(std.testing.allocator);
+    const cases = [_]struct { binding: []const u8, event: vt.input.KeyEvent }{
+        .{ .binding = "ctrl+shift+c=scroll_page_lines:-3", .event = .{ .key = .key_c, .unshifted_codepoint = 'c', .mods = .{ .ctrl = true, .shift = true } } },
+        .{ .binding = "ctrl+==scroll_page_lines:-3", .event = .{ .key = .equal, .unshifted_codepoint = '=', .mods = .{ .ctrl = true } } },
+        .{ .binding = "shift+PageUp=scroll_page_lines:-3", .event = .{ .key = .page_up, .mods = .{ .shift = true } } },
+    };
+    for (cases) |case| {
+        try config.set(std.testing.allocator, "keybind", case.binding);
+        for ([_]vt.input.KeyAction{ .press, .repeat, .release }) |action| {
+            var event = case.event;
+            event.action = action;
+            try std.testing.expectEqual(ScrollbackKeyAction{ .lines = -3 }, scrollbackKeyAction(&config, .primary, event).?);
+            try std.testing.expectEqual(ScrollbackKeyAction.passthrough, scrollbackKeyAction(&config, .alternate, event).?);
+        }
+    }
+    try config.set(std.testing.allocator, "keybind", "ctrl+shift+c=unbind");
+    try std.testing.expectEqual(ScrollbackKeyAction.passthrough, scrollbackKeyAction(&config, .primary, cases[0].event).?);
 }
 
 test "scrollback search scrolls a history match into the viewport" {

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -35,6 +35,19 @@ pub const MouseScrollMultiplier = struct {
     discrete: f64 = 3,
 };
 
+pub const Shortcut = struct {
+    key: vt.input.Key,
+    mods: vt.input.KeyMods = .{},
+
+    pub fn matches(self: Shortcut, event: vt.input.KeyEvent) bool {
+        return self.key == event.key and
+            self.mods.shift == event.mods.shift and
+            self.mods.ctrl == event.mods.ctrl and
+            self.mods.alt == event.mods.alt and
+            self.mods.super == event.mods.super;
+    }
+};
+
 pub const Theme = config_theme.Theme;
 pub const ThemeColors = config_theme.ThemeColors;
 pub const TerminalColor = config_theme.TerminalColor;
@@ -118,6 +131,9 @@ image_storage_limit: usize = 320 * 1000 * 1000,
 mouse_scroll_multiplier: MouseScrollMultiplier = .{},
 /// Whether finger scrolling continues with inertial motion after release.
 inertial_scrolling: bool = true,
+/// Shortcuts that move the primary-screen scrollback viewport by one line.
+scroll_line_up_key: Shortcut = .{ .key = .arrow_up, .mods = .{ .shift = true } },
+scroll_line_down_key: Shortcut = .{ .key = .arrow_down, .mods = .{ .shift = true } },
 /// Duration of the post-copy selection flash in milliseconds; 0 disables it.
 copy_highlight_duration: u32 = 200,
 /// Effective alpha of the default terminal background. Keeping this as an
@@ -253,6 +269,10 @@ pub fn set(self: *Config, arena: std.mem.Allocator, key: []const u8, value: []co
         self.image_storage_limit = limit;
     } else if (std.mem.eql(u8, key, "mouse-scroll-multiplier")) {
         self.mouse_scroll_multiplier = try parseMouseScrollMultiplier(self.mouse_scroll_multiplier, value);
+    } else if (std.mem.eql(u8, key, "scroll-line-up-key")) {
+        self.scroll_line_up_key = try parseShortcut(value);
+    } else if (std.mem.eql(u8, key, "scroll-line-down-key")) {
+        self.scroll_line_down_key = try parseShortcut(value);
     } else if (std.mem.eql(u8, key, "inertial-scrolling")) {
         self.inertial_scrolling = if (std.mem.eql(u8, value, "true"))
             true
@@ -335,6 +355,51 @@ fn parseMetricModifier(value: []const u8) error{InvalidValue}!MetricModifier {
     return .{
         .absolute = std.fmt.parseInt(i32, trimmed, 10) catch return error.InvalidValue,
     };
+}
+
+fn parseShortcut(value: []const u8) error{InvalidValue}!Shortcut {
+    var key: ?vt.input.Key = null;
+    var mods: vt.input.KeyMods = .{};
+    var tokens = std.mem.splitScalar(u8, value, '+');
+    while (tokens.next()) |raw_token| {
+        const token = std.mem.trim(u8, raw_token, " \t");
+        if (token.len == 0) return error.InvalidValue;
+
+        if (std.ascii.eqlIgnoreCase(token, "shift")) {
+            if (mods.shift) return error.InvalidValue;
+            mods.shift = true;
+        } else if (std.ascii.eqlIgnoreCase(token, "ctrl") or
+            std.ascii.eqlIgnoreCase(token, "control"))
+        {
+            if (mods.ctrl) return error.InvalidValue;
+            mods.ctrl = true;
+        } else if (std.ascii.eqlIgnoreCase(token, "alt")) {
+            if (mods.alt) return error.InvalidValue;
+            mods.alt = true;
+        } else if (std.ascii.eqlIgnoreCase(token, "super")) {
+            if (mods.super) return error.InvalidValue;
+            mods.super = true;
+        } else {
+            if (key != null) return error.InvalidValue;
+            key = try parseShortcutKey(token);
+        }
+    }
+    return .{ .key = key orelse return error.InvalidValue, .mods = mods };
+}
+
+fn parseShortcutKey(value: []const u8) error{InvalidValue}!vt.input.Key {
+    if (value.len == 1) {
+        return vt.input.Key.fromASCII(std.ascii.toLower(value[0])) orelse error.InvalidValue;
+    }
+    if (std.ascii.eqlIgnoreCase(value, "up")) return .arrow_up;
+    if (std.ascii.eqlIgnoreCase(value, "down")) return .arrow_down;
+    if (std.ascii.eqlIgnoreCase(value, "left")) return .arrow_left;
+    if (std.ascii.eqlIgnoreCase(value, "right")) return .arrow_right;
+    if (std.ascii.eqlIgnoreCase(value, "page-up")) return .page_up;
+    if (std.ascii.eqlIgnoreCase(value, "page-down")) return .page_down;
+    if (std.ascii.eqlIgnoreCase(value, "home")) return .home;
+    if (std.ascii.eqlIgnoreCase(value, "end")) return .end;
+    return vt.input.Key.fromW3C(value) orelse error.InvalidValue;
 }
 
 fn parseCommand(arena: std.mem.Allocator, value: []const u8) SetError!Command {
@@ -538,6 +603,14 @@ test "defaults" {
     try std.testing.expectEqual(@as(f64, 1), config.mouse_scroll_multiplier.precision);
     try std.testing.expectEqual(@as(f64, 3), config.mouse_scroll_multiplier.discrete);
     try std.testing.expect(config.inertial_scrolling);
+    try std.testing.expect(config.scroll_line_up_key.matches(.{
+        .key = .arrow_up,
+        .mods = .{ .shift = true },
+    }));
+    try std.testing.expect(config.scroll_line_down_key.matches(.{
+        .key = .arrow_down,
+        .mods = .{ .shift = true },
+    }));
     try std.testing.expectEqual(@as(u32, 200), config.copy_highlight_duration);
     try std.testing.expectEqual(@as(u8, 255), config.background_opacity);
     try std.testing.expect(config.background_blur);
@@ -578,6 +651,9 @@ test "parse config" {
         \\scrollback-limit = 50000000
         \\image-storage-limit = 50000000
         \\mouse-scroll-multiplier = precision:1.5,discrete:5
+        \\scroll-line-up-key = ctrl+shift+k
+        \\scroll-line-down-key = alt+j
+        \\scroll-line-up-key = shift+not-a-key
         \\inertial-scrolling = false
         \\copy-highlight-duration = 250
         \\background-opacity = 0.8
@@ -611,6 +687,14 @@ test "parse config" {
     try std.testing.expectEqual(@as(usize, 50_000_000), config.image_storage_limit);
     try std.testing.expectEqual(@as(f64, 1.5), config.mouse_scroll_multiplier.precision);
     try std.testing.expectEqual(@as(f64, 5), config.mouse_scroll_multiplier.discrete);
+    try std.testing.expect(config.scroll_line_up_key.matches(.{
+        .key = .key_k,
+        .mods = .{ .ctrl = true, .shift = true },
+    }));
+    try std.testing.expect(config.scroll_line_down_key.matches(.{
+        .key = .key_j,
+        .mods = .{ .alt = true },
+    }));
     try std.testing.expect(!config.inertial_scrolling);
     try std.testing.expectEqual(@as(u32, 250), config.copy_highlight_duration);
     try std.testing.expectEqual(@as(u8, 204), config.background_opacity);

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -1,7 +1,7 @@
 //! Configuration: a flat `key = value` file, one entry per line, with
 //! `#` comments. Located at $XDG_CONFIG_HOME/monstar/config (falling
 //! back to ~/.config/monstar/config). Missing file means defaults;
-//! invalid lines warn and keep their default.
+//! invalid lines warn and leave previous settings unchanged.
 
 const Config = @This();
 
@@ -9,6 +9,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const vt = @import("ghostty-vt");
 const config_theme = @import("config_theme.zig");
+const keybind = @import("keybind.zig");
 
 const log = std.log.scoped(.config);
 const baseline_dpi = 96.0;
@@ -33,19 +34,6 @@ pub const Command = union(enum) {
 pub const MouseScrollMultiplier = struct {
     precision: f64 = 1,
     discrete: f64 = 3,
-};
-
-pub const Shortcut = struct {
-    key: vt.input.Key,
-    mods: vt.input.KeyMods = .{},
-
-    pub fn matches(self: Shortcut, event: vt.input.KeyEvent) bool {
-        return self.key == event.key and
-            self.mods.shift == event.mods.shift and
-            self.mods.ctrl == event.mods.ctrl and
-            self.mods.alt == event.mods.alt and
-            self.mods.super == event.mods.super;
-    }
 };
 
 pub const Theme = config_theme.Theme;
@@ -131,9 +119,8 @@ image_storage_limit: usize = 320 * 1000 * 1000,
 mouse_scroll_multiplier: MouseScrollMultiplier = .{},
 /// Whether finger scrolling continues with inertial motion after release.
 inertial_scrolling: bool = true,
-/// Shortcuts that move the primary-screen scrollback viewport by one line.
-scroll_line_up_key: Shortcut = .{ .key = .arrow_up, .mods = .{ .shift = true } },
-scroll_line_down_key: Shortcut = .{ .key = .arrow_down, .mods = .{ .shift = true } },
+/// User keybindings, backed by the config arena. Defaults are resolved separately.
+keybinds: std.ArrayList(keybind.Binding) = .empty,
 /// Duration of the post-copy selection flash in milliseconds; 0 disables it.
 copy_highlight_duration: u32 = 200,
 /// Effective alpha of the default terminal background. Keeping this as an
@@ -269,10 +256,8 @@ pub fn set(self: *Config, arena: std.mem.Allocator, key: []const u8, value: []co
         self.image_storage_limit = limit;
     } else if (std.mem.eql(u8, key, "mouse-scroll-multiplier")) {
         self.mouse_scroll_multiplier = try parseMouseScrollMultiplier(self.mouse_scroll_multiplier, value);
-    } else if (std.mem.eql(u8, key, "scroll-line-up-key")) {
-        self.scroll_line_up_key = try parseShortcut(value);
-    } else if (std.mem.eql(u8, key, "scroll-line-down-key")) {
-        self.scroll_line_down_key = try parseShortcut(value);
+    } else if (std.mem.eql(u8, key, "keybind")) {
+        try keybind.put(&self.keybinds, arena, value);
     } else if (std.mem.eql(u8, key, "inertial-scrolling")) {
         self.inertial_scrolling = if (std.mem.eql(u8, value, "true"))
             true
@@ -355,51 +340,6 @@ fn parseMetricModifier(value: []const u8) error{InvalidValue}!MetricModifier {
     return .{
         .absolute = std.fmt.parseInt(i32, trimmed, 10) catch return error.InvalidValue,
     };
-}
-
-fn parseShortcut(value: []const u8) error{InvalidValue}!Shortcut {
-    var key: ?vt.input.Key = null;
-    var mods: vt.input.KeyMods = .{};
-    var tokens = std.mem.splitScalar(u8, value, '+');
-    while (tokens.next()) |raw_token| {
-        const token = std.mem.trim(u8, raw_token, " \t");
-        if (token.len == 0) return error.InvalidValue;
-
-        if (std.ascii.eqlIgnoreCase(token, "shift")) {
-            if (mods.shift) return error.InvalidValue;
-            mods.shift = true;
-        } else if (std.ascii.eqlIgnoreCase(token, "ctrl") or
-            std.ascii.eqlIgnoreCase(token, "control"))
-        {
-            if (mods.ctrl) return error.InvalidValue;
-            mods.ctrl = true;
-        } else if (std.ascii.eqlIgnoreCase(token, "alt")) {
-            if (mods.alt) return error.InvalidValue;
-            mods.alt = true;
-        } else if (std.ascii.eqlIgnoreCase(token, "super")) {
-            if (mods.super) return error.InvalidValue;
-            mods.super = true;
-        } else {
-            if (key != null) return error.InvalidValue;
-            key = try parseShortcutKey(token);
-        }
-    }
-    return .{ .key = key orelse return error.InvalidValue, .mods = mods };
-}
-
-fn parseShortcutKey(value: []const u8) error{InvalidValue}!vt.input.Key {
-    if (value.len == 1) {
-        return vt.input.Key.fromASCII(std.ascii.toLower(value[0])) orelse error.InvalidValue;
-    }
-    if (std.ascii.eqlIgnoreCase(value, "up")) return .arrow_up;
-    if (std.ascii.eqlIgnoreCase(value, "down")) return .arrow_down;
-    if (std.ascii.eqlIgnoreCase(value, "left")) return .arrow_left;
-    if (std.ascii.eqlIgnoreCase(value, "right")) return .arrow_right;
-    if (std.ascii.eqlIgnoreCase(value, "page-up")) return .page_up;
-    if (std.ascii.eqlIgnoreCase(value, "page-down")) return .page_down;
-    if (std.ascii.eqlIgnoreCase(value, "home")) return .home;
-    if (std.ascii.eqlIgnoreCase(value, "end")) return .end;
-    return vt.input.Key.fromW3C(value) orelse error.InvalidValue;
 }
 
 fn parseCommand(arena: std.mem.Allocator, value: []const u8) SetError!Command {
@@ -603,14 +543,14 @@ test "defaults" {
     try std.testing.expectEqual(@as(f64, 1), config.mouse_scroll_multiplier.precision);
     try std.testing.expectEqual(@as(f64, 3), config.mouse_scroll_multiplier.discrete);
     try std.testing.expect(config.inertial_scrolling);
-    try std.testing.expect(config.scroll_line_up_key.matches(.{
+    try std.testing.expectEqual(@as(i16, -1), keybind.getEvent(config.keybinds.items, .{
         .key = .arrow_up,
         .mods = .{ .shift = true },
-    }));
-    try std.testing.expect(config.scroll_line_down_key.matches(.{
+    }).?.scroll_page_lines);
+    try std.testing.expectEqual(@as(i16, 1), keybind.getEvent(config.keybinds.items, .{
         .key = .arrow_down,
         .mods = .{ .shift = true },
-    }));
+    }).?.scroll_page_lines);
     try std.testing.expectEqual(@as(u32, 200), config.copy_highlight_duration);
     try std.testing.expectEqual(@as(u8, 255), config.background_opacity);
     try std.testing.expect(config.background_blur);
@@ -651,9 +591,10 @@ test "parse config" {
         \\scrollback-limit = 50000000
         \\image-storage-limit = 50000000
         \\mouse-scroll-multiplier = precision:1.5,discrete:5
-        \\scroll-line-up-key = ctrl+shift+k
-        \\scroll-line-down-key = alt+j
-        \\scroll-line-up-key = shift+not-a-key
+        \\keybind = ctrl+shift+k=scroll_page_lines:-1
+        \\keybind = alt+j=scroll_page_lines:1
+        \\keybind = ctrl+shift+k=scroll_page_lines:-5
+        \\keybind = ctrl+shift+k=scroll_page_lines:invalid
         \\inertial-scrolling = false
         \\copy-highlight-duration = 250
         \\background-opacity = 0.8
@@ -687,14 +628,16 @@ test "parse config" {
     try std.testing.expectEqual(@as(usize, 50_000_000), config.image_storage_limit);
     try std.testing.expectEqual(@as(f64, 1.5), config.mouse_scroll_multiplier.precision);
     try std.testing.expectEqual(@as(f64, 5), config.mouse_scroll_multiplier.discrete);
-    try std.testing.expect(config.scroll_line_up_key.matches(.{
+    try std.testing.expectEqual(@as(i16, -5), keybind.getEvent(config.keybinds.items, .{
         .key = .key_k,
+        .unshifted_codepoint = 'k',
         .mods = .{ .ctrl = true, .shift = true },
-    }));
-    try std.testing.expect(config.scroll_line_down_key.matches(.{
+    }).?.scroll_page_lines);
+    try std.testing.expectEqual(@as(i16, 1), keybind.getEvent(config.keybinds.items, .{
         .key = .key_j,
+        .unshifted_codepoint = 'j',
         .mods = .{ .alt = true },
-    }));
+    }).?.scroll_page_lines);
     try std.testing.expect(!config.inertial_scrolling);
     try std.testing.expectEqual(@as(u32, 250), config.copy_highlight_duration);
     try std.testing.expectEqual(@as(u8, 204), config.background_opacity);
@@ -719,6 +662,25 @@ test "unknown override is rejected" {
         error.UnknownKey,
         config.applyOverride(std.testing.allocator, "font-famly=monospace"),
     );
+}
+
+test "keybind overrides and reloading start from defaults" {
+    var arena_state: std.heap.ArenaAllocator = .init(std.testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var config = parse(arena,
+        \\keybind = alt+j=scroll_page_lines:1
+        \\keybind = shift+up=unbind
+    );
+    try config.applyOverride(arena, "keybind=alt+j=scroll_page_lines:5");
+    try config.applyOverride(arena, "keybind=ctrl+==scroll_page_lines:-2");
+    try std.testing.expectEqual(@as(usize, 3), config.keybinds.items.len);
+    try std.testing.expectEqual(@as(i16, 5), keybind.getEvent(config.keybinds.items, .{ .unshifted_codepoint = 'j', .mods = .{ .alt = true } }).?.scroll_page_lines);
+    try std.testing.expectEqual(@as(i16, -2), keybind.getEvent(config.keybinds.items, .{ .unshifted_codepoint = '=', .mods = .{ .ctrl = true } }).?.scroll_page_lines);
+
+    config = parse(arena, "");
+    try std.testing.expectEqual(null, keybind.getEvent(config.keybinds.items, .{ .unshifted_codepoint = 'j', .mods = .{ .alt = true } }));
+    try std.testing.expectEqual(@as(i16, -1), keybind.getEvent(config.keybinds.items, .{ .key = .arrow_up, .mods = .{ .shift = true } }).?.scroll_page_lines);
 }
 
 test "direct command parsing" {

--- a/src/Keyboard.zig
+++ b/src/Keyboard.zig
@@ -736,6 +736,38 @@ test "Dvorak writing key exposes its logical shortcut codepoint" {
     try std.testing.expectEqual(@as(u21, 'c'), event.unshifted_codepoint);
 }
 
+test "configured Unicode and physical bindings on US and Dvorak keyboards" {
+    const keybind = @import("keybind.zig");
+    var bindings: std.ArrayList(keybind.Binding) = .empty;
+    defer bindings.deinit(std.testing.allocator);
+    try keybind.put(&bindings, std.testing.allocator, "ctrl+shift+k=scroll_page_lines:-5");
+    try keybind.put(&bindings, std.testing.allocator, "alt+j=scroll_page_lines:1");
+    for ([_]?[*:0]const u8{ null, "dvorak" }) |variant| {
+        var kb = try testKeyboardWithLayout("us", variant);
+        defer kb.deinit();
+        var buf: [16]u8 = undefined;
+        _ = c.xkb_state_update_key(kb.state.?, 29 + 8, c.XKB_KEY_DOWN);
+        _ = c.xkb_state_update_key(kb.state.?, 42 + 8, c.XKB_KEY_DOWN);
+        // Dvorak K is at the physical V position; J is at physical C.
+        const k: u32 = if (variant == null) 37 else 47;
+        const j: u32 = if (variant == null) 36 else 46;
+        for ([_]vt.input.KeyAction{ .press, .repeat, .release }) |action| {
+            const event = kb.translate(&buf, k, action).?;
+            try std.testing.expectEqual(@as(u21, 'k'), event.unshifted_codepoint);
+            try std.testing.expectEqual(@as(i16, -5), keybind.getEvent(bindings.items, event).?.scroll_page_lines);
+        }
+        _ = c.xkb_state_update_key(kb.state.?, 29 + 8, c.XKB_KEY_UP);
+        _ = c.xkb_state_update_key(kb.state.?, 42 + 8, c.XKB_KEY_UP);
+        _ = c.xkb_state_update_key(kb.state.?, 56 + 8, c.XKB_KEY_DOWN);
+        try std.testing.expectEqual(@as(i16, 1), keybind.getEvent(bindings.items, kb.translate(&buf, j, .press).?).?.scroll_page_lines);
+        if (variant != null) {
+            try std.testing.expectEqual(null, keybind.getEvent(bindings.items, kb.translate(&buf, 36, .press).?));
+            try keybind.put(&bindings, std.testing.allocator, "alt+KeyJ=scroll_page_lines:3");
+            try std.testing.expectEqual(@as(i16, 3), keybind.getEvent(bindings.items, kb.translate(&buf, 36, .press).?).?.scroll_page_lines);
+        }
+    }
+}
+
 test "virtual keyboard text on a non-writing keycode ignores the physical key" {
     // wtype assigns keycodes by first appearance, so text lands on evdev 29 (ctrl), 15 (tab), 14 (backspace), 59 (f1), 96 (kp enter), 103 (up), ...
     try std.testing.expectEqual(vt.input.Key.unidentified, remapKey(.control_left, c.XKB_KEY_Cyrillic_sha));

--- a/src/keybind.zig
+++ b/src/keybind.zig
@@ -1,0 +1,272 @@
+//! Single-key Ghostty-style bindings. User entries override defaults by trigger;
+//! lookup prefers physical keys, then generated text, then unshifted text.
+//! `unbind` entries suppress defaults, including App's remaining fixed shortcuts.
+//!
+//! Trigger parsing and Unicode comparison adapted from Ghostty's
+//! src/input/Binding.zig at 8144ef4e73e70a4e9942fceb319819005f07fd37.
+
+// MIT License
+// Copyright (c) 2024 Mitchell Hashimoto, Ghostty contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const std = @import("std");
+const vt = @import("ghostty-vt");
+const uucode = @import("uucode");
+
+pub const Action = union(enum) {
+    scroll_page_lines: i16,
+    unbind,
+};
+
+pub const Binding = struct {
+    trigger: Trigger,
+    action: Action,
+};
+
+pub const Trigger = struct {
+    key: union(enum) { physical: vt.input.Key, unicode: u21 },
+    mods: vt.input.KeyMods = .{},
+
+    fn equal(a: Trigger, b: Trigger) bool {
+        if (!a.mods.binding().equal(b.mods.binding())) return false;
+        if (std.meta.activeTag(a.key) != std.meta.activeTag(b.key)) return false;
+        return switch (a.key) {
+            .physical => |key| key == b.key.physical,
+            .unicode => |cp| std.mem.eql(u21, &foldedCodepoint(cp), &foldedCodepoint(b.key.unicode)),
+        };
+    }
+};
+
+const defaults = [_]Binding{
+    .{ .trigger = .{ .key = .{ .physical = .arrow_up }, .mods = .{ .shift = true } }, .action = .{ .scroll_page_lines = -1 } },
+    .{ .trigger = .{ .key = .{ .physical = .arrow_down }, .mods = .{ .shift = true } }, .action = .{ .scroll_page_lines = 1 } },
+};
+
+/// Parse without allocating. Only single-key triggers and the actions in Action
+/// are supported; unsupported Ghostty sequences, flags and actions are errors.
+pub fn parse(input: []const u8) error{InvalidValue}!Binding {
+    // Skip '=' when it is the trigger key, e.g. ctrl+==scroll_page_lines:-1
+    // or =+ctrl=scroll_page_lines:-1 (the key need not follow the modifiers).
+    var offset: usize = 0;
+    const eq = while (std.mem.indexOfScalar(u8, input[offset..], '=')) |relative| {
+        const idx = offset + relative;
+        if (idx + 1 < input.len and (input[idx + 1] == '+' or input[idx + 1] == '=')) {
+            offset = idx + 1;
+            continue;
+        }
+        break idx;
+    } else return error.InvalidValue;
+
+    const action_text = std.mem.trim(u8, input[eq + 1 ..], " \t");
+    const action: Action = if (std.mem.eql(u8, action_text, "unbind"))
+        .unbind
+    else if (std.mem.startsWith(u8, action_text, "scroll_page_lines:"))
+        .{ .scroll_page_lines = std.fmt.parseInt(i16, action_text["scroll_page_lines:".len..], 10) catch return error.InvalidValue }
+    else
+        return error.InvalidValue;
+    return .{ .trigger = try parseTrigger(std.mem.trim(u8, input[0..eq], " \t")), .action = action };
+}
+
+fn parseTrigger(input: []const u8) error{InvalidValue}!Trigger {
+    var key: ?@FieldType(Trigger, "key") = null;
+    var mods: vt.input.KeyMods = .{};
+    var rem = input;
+    loop: while (rem.len > 0) {
+        const idx = std.mem.indexOfScalar(u8, rem, '+') orelse rem.len;
+        const part = rem[0..idx];
+        rem = if (idx >= rem.len) "" else rem[idx + 1 ..];
+
+        inline for (.{ "shift", "ctrl", "alt", "super" }) |name| {
+            if (std.mem.eql(u8, part, name)) {
+                if (@field(mods, name)) return error.InvalidValue;
+                @field(mods, name) = true;
+                continue :loop;
+            }
+        }
+        inline for (.{
+            .{ "control", "ctrl" },
+            .{ "opt", "alt" },
+            .{ "option", "alt" },
+            .{ "cmd", "super" },
+            .{ "command", "super" },
+        }) |pair| {
+            if (std.mem.eql(u8, part, pair[0])) {
+                if (@field(mods, pair[1])) return error.InvalidValue;
+                @field(mods, pair[1]) = true;
+                continue :loop;
+            }
+        }
+
+        if (key != null) return error.InvalidValue;
+        if (part.len == 0) {
+            key = .{ .unicode = '+' };
+        } else if (singleCodepoint(part)) |cp| {
+            key = .{ .unicode = cp };
+        } else if (vt.input.Key.fromW3C(part)) |physical| {
+            if (physical == .unidentified) return error.InvalidValue;
+            key = .{ .physical = physical };
+        } else {
+            // Ghostty's common pre-W3C navigation aliases.
+            const physical = std.StaticStringMap(vt.input.Key).initComptime(.{
+                .{ "up", .arrow_up },
+                .{ "down", .arrow_down },
+                .{ "left", .arrow_left },
+                .{ "right", .arrow_right },
+            }).get(part) orelse return error.InvalidValue;
+            key = .{ .physical = physical };
+        }
+    }
+    return .{ .key = key orelse return error.InvalidValue, .mods = mods };
+}
+
+fn singleCodepoint(text: []const u8) ?u21 {
+    const view = std.unicode.Utf8View.init(text) catch return null;
+    var it = view.iterator();
+    const cp = it.nextCodepoint() orelse return null;
+    return if (it.nextCodepoint() == null) cp else null;
+}
+
+fn foldedCodepoint(cp: u21) [3]u21 {
+    if (uucode.ascii.isAlphabetic(cp)) return .{ uucode.ascii.toLower(cp), 0, 0 };
+    var buffer: [1]u21 = undefined;
+    const slice = uucode.get(.case_folding_full, cp).with(&buffer, cp);
+    var result: [3]u21 = @splat(0);
+    std.debug.assert(slice.len <= result.len);
+    @memcpy(result[0..slice.len], slice);
+    return result;
+}
+
+/// Replace an existing trigger or append a new one. Invalid input and allocation
+/// failure leave the list unchanged. Storage belongs to the supplied allocator.
+pub fn put(bindings: *std.ArrayList(Binding), alloc: std.mem.Allocator, input: []const u8) error{ InvalidValue, OutOfMemory }!void {
+    const binding = try parse(input);
+    for (bindings.items) |*existing| {
+        if (existing.trigger.equal(binding.trigger)) {
+            existing.* = binding;
+            return;
+        }
+    }
+    try bindings.append(alloc, binding);
+}
+
+fn get(bindings: []const Binding, trigger: Trigger) ?Action {
+    for (bindings) |binding| {
+        if (binding.trigger.equal(trigger)) return binding.action;
+    }
+    for (defaults) |binding| {
+        if (binding.trigger.equal(trigger)) return binding.action;
+    }
+    return null;
+}
+
+/// Return a matching action, or `unbind` when the event should bypass fixed
+/// shortcuts. Lock keys, modifier sides and consumed modifiers do not alter
+/// matching. Unbinding a physical trigger still permits a Unicode binding.
+pub fn getEvent(bindings: []const Binding, event: vt.input.KeyEvent) ?Action {
+    const keys = [_]?@FieldType(Trigger, "key"){
+        .{ .physical = event.key },
+        if (singleCodepoint(event.utf8)) |cp| .{ .unicode = cp } else null,
+        if (event.unshifted_codepoint > 0) .{ .unicode = event.unshifted_codepoint } else null,
+    };
+    var unbound = false;
+    for (keys) |maybe_key| {
+        const key = maybe_key orelse continue;
+        const action = get(bindings, .{ .key = key, .mods = event.mods.binding() }) orelse continue;
+        if (action == .unbind) {
+            unbound = true;
+            continue;
+        }
+        return action;
+    }
+    return if (unbound) .unbind else null;
+}
+
+test "Ghostty single-key syntax and action parameters" {
+    const cases = [_]struct { text: []const u8, key: @FieldType(Trigger, "key"), mods: vt.input.KeyMods }{
+        .{ .text = "ctrl+shift+k", .key = .{ .unicode = 'k' }, .mods = .{ .ctrl = true, .shift = true } },
+        .{ .text = "option+ö", .key = .{ .unicode = 'ö' }, .mods = .{ .alt = true } },
+        .{ .text = "command+PageUp", .key = .{ .physical = .page_up }, .mods = .{ .super = true } },
+        .{ .text = "control+KeyK", .key = .{ .physical = .key_k }, .mods = .{ .ctrl = true } },
+        .{ .text = "shift+up", .key = .{ .physical = .arrow_up }, .mods = .{ .shift = true } },
+        .{ .text = "ctrl++", .key = .{ .unicode = '+' }, .mods = .{ .ctrl = true } },
+        .{ .text = "=+ctrl", .key = .{ .unicode = '=' }, .mods = .{ .ctrl = true } },
+        .{ .text = "ctrl+=", .key = .{ .unicode = '=' }, .mods = .{ .ctrl = true } },
+        .{ .text = "shift+?", .key = .{ .unicode = '?' }, .mods = .{ .shift = true } },
+    };
+    for (cases) |case| {
+        var buf: [128]u8 = undefined;
+        const binding = try parse(try std.fmt.bufPrint(&buf, "{s}=scroll_page_lines:-5", .{case.text}));
+        try std.testing.expectEqualDeep(case.key, binding.trigger.key);
+        try std.testing.expectEqual(case.mods, binding.trigger.mods);
+        try std.testing.expectEqual(@as(i16, -5), binding.action.scroll_page_lines);
+    }
+    try std.testing.expectEqual(@as(i16, -32768), (try parse("a=scroll_page_lines:-32768")).action.scroll_page_lines);
+    try std.testing.expectEqual(@as(i16, 32767), (try parse("a=scroll_page_lines:32767")).action.scroll_page_lines);
+    try std.testing.expectEqual(@as(i16, 0), (try parse("a=scroll_page_lines:0")).action.scroll_page_lines);
+    for ([_][]const u8{
+        "",                    "ctrl=unbind",               "ctrl+control+a=unbind",      "a+b=unbind",              "=unbind",
+        "a=scroll_page_lines", "a=scroll_page_lines:32768", "a=scroll_page_lines:-32769", "a=scroll_page_lines:1.5", "a=scroll_page_lines:",
+        "a=unknown",           "a=unbind:1",                "ctrl+not-a-key=unbind",      "a>b=unbind",              "global:a=unbind",
+        "chain=unbind",        "catch_all=unbind",          "\xff=unbind",
+    }) |text| try std.testing.expectError(error.InvalidValue, parse(text));
+}
+
+test "repeatable bindings replace, unbind and restore without losing other triggers" {
+    var bindings: std.ArrayList(Binding) = .empty;
+    defer bindings.deinit(std.testing.allocator);
+    try put(&bindings, std.testing.allocator, "alt+j=scroll_page_lines:1");
+    try put(&bindings, std.testing.allocator, "alt+k=scroll_page_lines:-1");
+    try put(&bindings, std.testing.allocator, "alt+J=scroll_page_lines:5");
+    try std.testing.expectEqual(@as(usize, 2), bindings.items.len);
+    const event: vt.input.KeyEvent = .{ .key = .key_j, .unshifted_codepoint = 'j', .mods = .{ .alt = true } };
+    try std.testing.expectEqual(@as(i16, 5), getEvent(bindings.items, event).?.scroll_page_lines);
+    try std.testing.expectError(error.InvalidValue, put(&bindings, std.testing.allocator, "alt+j=scroll_page_lines:no"));
+    try std.testing.expectEqual(@as(i16, 5), getEvent(bindings.items, event).?.scroll_page_lines);
+    try put(&bindings, std.testing.allocator, "alt+j=unbind");
+    try std.testing.expectEqual(Action.unbind, getEvent(bindings.items, event).?);
+    try put(&bindings, std.testing.allocator, "alt+j=scroll_page_lines:2");
+    try std.testing.expectEqual(@as(i16, 2), getEvent(bindings.items, event).?.scroll_page_lines);
+    try put(&bindings, std.testing.allocator, "shift+up=unbind");
+    try std.testing.expectEqual(Action.unbind, getEvent(bindings.items, .{ .key = .arrow_up, .mods = .{ .shift = true } }).?);
+}
+
+test "physical then generated then unshifted matching with exact modifiers" {
+    var bindings: std.ArrayList(Binding) = .empty;
+    defer bindings.deinit(std.testing.allocator);
+    try put(&bindings, std.testing.allocator, "ctrl+shift+KeyK=scroll_page_lines:3");
+    try put(&bindings, std.testing.allocator, "ctrl+shift+?=scroll_page_lines:2");
+    try put(&bindings, std.testing.allocator, "ctrl+shift+ö=scroll_page_lines:1");
+    var event: vt.input.KeyEvent = .{
+        .key = .key_k,
+        .utf8 = "?",
+        .unshifted_codepoint = 'ö',
+        .mods = .{ .ctrl = true, .shift = true, .caps_lock = true, .num_lock = true, .sides = .{ .ctrl = .right } },
+        .consumed_mods = .{ .shift = true },
+    };
+    try std.testing.expectEqual(@as(i16, 3), getEvent(bindings.items, event).?.scroll_page_lines);
+    try put(&bindings, std.testing.allocator, "ctrl+shift+KeyK=unbind");
+    try std.testing.expectEqual(@as(i16, 2), getEvent(bindings.items, event).?.scroll_page_lines);
+    event.utf8 = "Ö";
+    try std.testing.expectEqual(@as(i16, 1), getEvent(bindings.items, event).?.scroll_page_lines);
+    event.utf8 = "multiple codepoints";
+    try std.testing.expectEqual(@as(i16, 1), getEvent(bindings.items, event).?.scroll_page_lines);
+    event.mods.alt = true;
+    try std.testing.expectEqual(null, getEvent(bindings.items, event));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -389,6 +389,7 @@ test {
     _ = @import("config_theme.zig");
     _ = @import("glyph_constraints.zig");
     _ = @import("Keyboard.zig");
+    _ = @import("keybind.zig");
     _ = @import("KittyImageCache.zig");
     _ = @import("kitty_graphics.zig");
     _ = Link;


### PR DESCRIPTION
## Problem

Monstar supports page and boundary scrollback navigation. It has no shortcut for one-line movement.

## Change

- Add `Shift+Up` and `Shift+Down` as the default one-line shortcuts.
- Add `scroll-line-up-key` and `scroll-line-down-key` configuration settings.
- Accept modifier combinations with ASCII keys or named navigation keys.
- Keep all scrollback shortcuts disabled on the alternate screen.
- Document the settings and default shortcuts.

## Verification

- `zig build fmt`
- `zig build test`
- `zig build`
- Default `Shift+Up` moved the viewport from line 135 to line 134.
- Configured `Ctrl+Shift+Up` moved the viewport from line 131 to line 130.
