### PR TITLE
Expose terminfo package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,28 @@
             installCheckPhase = ''
               TERMINFO="$out/share/terminfo" infocmp -x monstar >/dev/null
             '';
+
+            passthru.terminfo = pkgs.stdenv.mkDerivation {
+              pname = "monstar-terminfo";
+              inherit (finalAttrs) version;
+              src = finalAttrs.finalPackage;
+
+              dontUnpack = true;
+              dontFixup = true;
+
+              installPhase = ''
+                runHook preInstall
+                install -d "$out/share/terminfo"
+                cp -r "$src/share/terminfo/." "$out/share/terminfo"
+                runHook postInstall
+              '';
+
+              doInstallCheck = true;
+              nativeBuildInputs = [ pkgs.ncurses ];
+              installCheckPhase = ''
+                TERMINFO="$out/share/terminfo" infocmp -x monstar >/dev/null
+              '';
+            };
           });
         });
 


### PR DESCRIPTION
Thank you for your work on Monstar.

This allows installing just the terminfo on servers, without having to install the entirety of Monstar. For example:


```nix
# in flake
monstar = inputs.monstar.packages.${system}.default;

# in the server module
environment.systemPackages = [ pkgs.ghostty.terminfo monstar.terminfo ];
```