### PR TITLE
selection: extend active drag after viewport scrolling

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -4437,6 +4437,7 @@ fn scrollLines(self: *App, lines_down: i32) void {
     }
 
     self.term.screens.active.pages.scroll(.{ .delta_row = lines_down });
+    if (self.selecting) self.extendSelection();
     self.revealScrollbar();
     self.needs_redraw = true;
     self.syncHoveredLink(true);


### PR DESCRIPTION
Selection did not update during scrolling, we have to move the mouse to trigger the update, which i think can be improved?