### PR TITLE
Implement gamma-correct blending

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,7 @@ pub fn build(b: *std.Build) void {
     scanner.addSystemProtocol("staging/xdg-system-bell/xdg-system-bell-v1.xml");
     scanner.addSystemProtocol("staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml");
     scanner.addSystemProtocol("staging/ext-background-effect/ext-background-effect-v1.xml");
+    scanner.addSystemProtocol("staging/color-management/color-management-v1.xml");
     scanner.addSystemProtocol("unstable/xdg-decoration/xdg-decoration-unstable-v1.xml");
     scanner.addSystemProtocol("unstable/primary-selection/primary-selection-unstable-v1.xml");
     scanner.addSystemProtocol("unstable/text-input/text-input-unstable-v3.xml");
@@ -47,6 +48,7 @@ pub fn build(b: *std.Build) void {
     scanner.generate("xdg_system_bell_v1", 1);
     scanner.generate("xdg_toplevel_icon_manager_v1", 1);
     scanner.generate("ext_background_effect_manager_v1", 1);
+    scanner.generate("wp_color_manager_v1", 1);
     scanner.generate("zxdg_decoration_manager_v1", 2);
     scanner.generate("wl_data_device_manager", 4);
     scanner.generate("zwp_primary_selection_device_manager_v1", 1);

--- a/dist/monstar.5
+++ b/dist/monstar.5
@@ -155,6 +155,17 @@ to explicit cell background colors too.
 The default is false.
 Selections, cursors, text, and terminal graphics retain their own opacity.
 .TP
+.BI gamma-correct-blending " = boolean"
+Blend text gamma-correctly in linear light, the same approach as the foot
+terminal emulator.
+The default is false.
+This requires a compositor that supports the wp-color-management-v1 protocol
+with parametric image descriptions (the ext_linear transfer function, sRGB
+primaries, and the perceptual render intent) as well as 16-bit shared memory
+buffers; otherwise monstar logs a warning and falls back to 8-bit rendering.
+When enabled, render buffers use 16 bits per channel, roughly doubling their
+memory usage.
+.TP
 .BI window-padding-x " = pixels[,pixels]"
 Set minimum left and right padding in logical pixels.
 One value applies to both sides; two values set left and right independently.

--- a/src/App.zig
+++ b/src/App.zig
@@ -596,6 +596,7 @@ pub fn init(
     const window = try Window.create(alloc, config.app_id, options.title, startup_size.window);
     errdefer window.destroy();
     window.setBufferAlpha(config.background_opacity < 255);
+    applyGammaCorrect(window, config.gamma_correct_blending);
     window.setBackgroundBlur(config.background_blur and config.background_opacity < 255);
 
     // Timerfds must be nonblocking: disarming a timerfd clears its
@@ -2215,6 +2216,17 @@ fn spawnEnvp(
     return slice.ptr;
 }
 
+/// Enable gamma-correct blending when the compositor supports it; warn and
+/// stay on 8-bit rendering otherwise. The trailing requestFullAsyncRedraw in
+/// applyConfig invalidates in-flight and held frames after a format switch.
+fn applyGammaCorrect(window: *Window, enabled: bool) void {
+    if (enabled and !window.gammaCorrectAvailable()) {
+        log.warn("gamma-correct blending requested but the compositor lacks support; rendering in 8-bit sRGB", .{});
+        return;
+    }
+    window.setGammaCorrect(enabled);
+}
+
 fn applyConfig(self: *App, new_config: Config) !void {
     const desired_font_size = Config.fontSizePixels(self.runtime_font_size orelse new_config.font_size, self.window.scale120);
     const new_font: Font = try .init(
@@ -2226,6 +2238,7 @@ fn applyConfig(self: *App, new_config: Config) !void {
 
     self.applyColorDefaultsForConfig(new_config);
     self.window.setBufferAlpha(new_config.background_opacity < 255);
+    applyGammaCorrect(self.window, new_config.gamma_correct_blending);
     self.window.setBackgroundBlur(new_config.background_blur and new_config.background_opacity < 255);
     self.window.toplevel.setAppId(new_config.app_id);
 
@@ -5840,9 +5853,16 @@ fn redrawReady(ctx: *anyopaque) void {
     self.needs_redraw = true;
 }
 
-fn findRenderingBuffer(self: *App, pixels: []u32) ?*Window.Buffer {
+fn findRenderingBuffer(self: *App, pixels: Renderer.PixelBuffer) ?*Window.Buffer {
     for (self.window.buffers.items) |buffer| {
-        if (buffer.rendering and buffer.pixels().ptr == pixels.ptr) return buffer;
+        if (!buffer.rendering) continue;
+        const buffer_pixels = buffer.pixels();
+        if (std.meta.activeTag(buffer_pixels) != std.meta.activeTag(pixels)) continue;
+        const matches = switch (pixels) {
+            .rgba8 => |p| buffer_pixels.rgba8.ptr == p.ptr,
+            .rgba16 => |p| buffer_pixels.rgba16.ptr == p.ptr,
+        };
+        if (matches) return buffer;
     }
     return null;
 }

--- a/src/AsyncRaster.zig
+++ b/src/AsyncRaster.zig
@@ -32,8 +32,8 @@ pub const Repair = union(enum) {
 /// are read-only. A returned `Result.job` preserves these borrows and does not
 /// transfer ownership of their backing storage.
 pub const Job = struct {
-    pixels: []u32,
-    source_pixels: ?[]const u32,
+    pixels: Renderer.PixelBuffer,
+    source_pixels: ?Renderer.PixelBuffer.Const,
     width: u31,
     height: u31,
     grid_x: u31,
@@ -488,7 +488,14 @@ fn workerMain(self: *AsyncRaster) void {
 }
 
 fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
-    const grid_pixels = gridPixels(job);
+    switch (job.pixels) {
+        inline else => |pixels| try self.renderJobT(job, pixels, damage),
+    }
+}
+
+fn renderJobT(self: *AsyncRaster, job: Job, pixels: anytype, damage: *Damage) !void {
+    const P = std.meta.Child(@TypeOf(pixels));
+    const grid_pixels = gridPixels(job, pixels);
     // Overlays draw outside the grid rows that dirty tracking accounts
     // for, so an overlay frame is always a full render with full damage.
     if (job.hasOverlay()) {
@@ -497,11 +504,11 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
         // so repair to it instead of re-rendering. Without this a
         // visible kitty image turns every submitted job into a full
         // render.
-        if (!job.overlay_dirty and self.state.dirty == .false and repairToPreviousFrame(job)) {
+        if (!job.overlay_dirty and self.state.dirty == .false and repairToPreviousFrameT(job, pixels)) {
             damage.* = .none;
             return;
         }
-        clearPadding(job, self.renderer.backgroundPixel(self.state.colors.background));
+        clearPadding(job, pixels, self.renderer.backgroundPixel(P, self.state.colors.background));
         if (job.kitty_items.len > 0) {
             try self.renderer.renderWithKittyItems(self.state, job.kitty_items, grid_pixels, job.grid_width, job.grid_height);
         } else {
@@ -526,7 +533,7 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
         if (job.scrollbar) |thumb| {
             self.renderer.renderScrollbarThumb(
                 self.state,
-                job.pixels,
+                pixels,
                 job.width,
                 job.height,
                 thumb,
@@ -536,8 +543,8 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
         return;
     }
     if (job.scroll_shift) |shift| {
-        clearPadding(job, self.renderer.backgroundPixel(self.state.colors.background));
-        if (scrollFromPreviousFrame(job, shift, self.font.cell_height)) {
+        clearPadding(job, pixels, self.renderer.backgroundPixel(P, self.state.colors.background));
+        if (scrollFromPreviousFrameT(job, pixels, shift, self.font.cell_height)) {
             try self.renderer.shiftCellState(self.state.rows, self.state.cols, shift);
             try self.renderer.renderDirty(self.state, grid_pixels, job.grid_width, job.grid_height);
             // Rasterization touched only dirty rows, but every retained row
@@ -553,13 +560,13 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
     }
     switch (self.state.dirty) {
         .full => {
-            clearPadding(job, self.renderer.backgroundPixel(self.state.colors.background));
+            clearPadding(job, pixels, self.renderer.backgroundPixel(P, self.state.colors.background));
             try self.renderer.render(self.state, grid_pixels, job.grid_width, job.grid_height);
             damage.* = .full;
         },
         .partial => {
-            if (!repairToPreviousFrame(job)) {
-                clearPadding(job, self.renderer.backgroundPixel(self.state.colors.background));
+            if (!repairToPreviousFrameT(job, pixels)) {
+                clearPadding(job, pixels, self.renderer.backgroundPixel(P, self.state.colors.background));
                 try self.renderer.render(self.state, grid_pixels, job.grid_width, job.grid_height);
                 damage.* = .full;
                 return;
@@ -568,8 +575,8 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
             damage.* = if (self.renderer.rendered_rects.items.len == 0) .none else .partial;
         },
         .false => {
-            if (!repairToPreviousFrame(job)) {
-                clearPadding(job, self.renderer.backgroundPixel(self.state.colors.background));
+            if (!repairToPreviousFrameT(job, pixels)) {
+                clearPadding(job, pixels, self.renderer.backgroundPixel(P, self.state.colors.background));
                 try self.renderer.render(self.state, grid_pixels, job.grid_width, job.grid_height);
                 damage.* = .full;
                 return;
@@ -579,38 +586,56 @@ fn renderJob(self: *AsyncRaster, job: Job, damage: *Damage) !void {
     }
 }
 
-fn gridPixels(job: Job) []u32 {
+fn gridPixels(job: Job, pixels: anytype) @TypeOf(pixels) {
     std.debug.assert(job.grid_x + job.grid_width <= job.width);
     std.debug.assert(job.grid_y + job.grid_height <= job.height);
     const offset = @as(usize, job.grid_y) * job.width + job.grid_x;
-    return job.pixels[offset..];
+    return pixels[offset..];
 }
 
-fn clearPadding(job: Job, color: u32) void {
-    @memset(job.pixels[0 .. @as(usize, job.grid_y) * job.width], color);
+fn clearPadding(job: Job, pixels: anytype, color: std.meta.Child(@TypeOf(pixels))) void {
+    @memset(pixels[0 .. @as(usize, job.grid_y) * job.width], color);
     const grid_bottom = @as(usize, job.grid_y + job.grid_height) * job.width;
-    @memset(job.pixels[grid_bottom..], color);
+    @memset(pixels[grid_bottom..], color);
     for (job.grid_y..job.grid_y + job.grid_height) |y| {
         const row = @as(usize, y) * job.width;
-        @memset(job.pixels[row .. row + job.grid_x], color);
+        @memset(pixels[row .. row + job.grid_x], color);
         const right = row + job.grid_x + job.grid_width;
-        @memset(job.pixels[right .. row + job.width], color);
+        @memset(pixels[right .. row + job.width], color);
     }
 }
 
+/// The job's previous-frame pixels when their format matches the target
+/// buffer's. A mismatch cannot happen (App retires old-format buffers),
+/// so treat it as "no usable source".
+fn jobSource(job: Job, comptime P: type) ?[]const P {
+    const source = job.source_pixels orelse return null;
+    return switch (source) {
+        .rgba8 => |s| if (P == u32) s else null,
+        .rgba16 => |s| if (P == u64) s else null,
+    };
+}
+
 fn repairToPreviousFrame(job: Job) bool {
+    return switch (job.pixels) {
+        inline else => |pixels| repairToPreviousFrameT(job, pixels),
+    };
+}
+
+fn repairToPreviousFrameT(job: Job, pixels: anytype) bool {
+    const P = std.meta.Child(@TypeOf(pixels));
     return switch (job.repair) {
         .none => true,
         .full => repair: {
-            const source = job.source_pixels orelse break :repair false;
-            if (source.len != job.pixels.len) break :repair false;
-            if (source.ptr != job.pixels.ptr) Renderer.copyPixels(job.pixels, source);
+            const source = jobSource(job, P) orelse break :repair false;
+            if (source.len != pixels.len) break :repair false;
+            if (source.ptr != pixels.ptr) Renderer.copyPixels(pixels, source);
             break :repair true;
         },
         .rects => |rects| repair: {
-            const source = job.source_pixels orelse break :repair false;
-            if (source.len != job.pixels.len) break :repair false;
-            if (source.ptr == job.pixels.ptr) break :repair true;
+            const source = jobSource(job, P) orelse break :repair false;
+            if (source.len != pixels.len) break :repair false;
+            if (source.ptr == pixels.ptr) break :repair true;
             for (rects) |rect| {
                 if (rect.x > job.width or rect.width > job.width - rect.x or
                     rect.y > job.height or rect.height > job.height - rect.y)
@@ -620,7 +645,7 @@ fn repairToPreviousFrame(job: Job) bool {
                 for (rect.y..rect.y + rect.height) |y| {
                     const offset = @as(usize, y) * job.width + rect.x;
                     Renderer.copyPixels(
-                        job.pixels[offset..][0..rect.width],
+                        pixels[offset..][0..rect.width],
                         source[offset..][0..rect.width],
                     );
                 }
@@ -634,16 +659,23 @@ fn repairToPreviousFrame(job: Job) bool {
 /// their new positions. This avoids a full stale-buffer repair followed by
 /// a second in-place shift when source and destination differ.
 fn scrollFromPreviousFrame(job: Job, shift_rows: isize, cell_height: u31) bool {
+    return switch (job.pixels) {
+        inline else => |pixels| scrollFromPreviousFrameT(job, pixels, shift_rows, cell_height),
+    };
+}
+
+fn scrollFromPreviousFrameT(job: Job, pixels: anytype, shift_rows: isize, cell_height: u31) bool {
+    const P = std.meta.Child(@TypeOf(pixels));
     const rows: usize = @abs(shift_rows);
     if (rows == 0) return false;
     const shift_pixels = rows * cell_height;
     if (shift_pixels >= job.grid_height) return false;
 
     const source = if (job.age == 1)
-        @as([]const u32, job.pixels)
+        @as([]const P, pixels)
     else
-        job.source_pixels orelse return false;
-    if (source.len != job.pixels.len) return false;
+        jobSource(job, P) orelse return false;
+    if (source.len != pixels.len) return false;
 
     const stride: usize = job.width;
     const grid_start = @as(usize, job.grid_y) * stride;
@@ -651,16 +683,16 @@ fn scrollFromPreviousFrame(job: Job, shift_rows: isize, cell_height: u31) bool {
     const offset = shift_pixels * stride;
     const retained = grid_end - grid_start - offset;
     if (shift_rows > 0) {
-        const dst = job.pixels[grid_start .. grid_start + retained];
+        const dst = pixels[grid_start .. grid_start + retained];
         const src = source[grid_start + offset .. grid_end];
-        if (source.ptr == job.pixels.ptr)
+        if (source.ptr == pixels.ptr)
             @memmove(dst, src)
         else
             Renderer.copyPixels(dst, src);
     } else {
-        const dst = job.pixels[grid_start + offset .. grid_end];
+        const dst = pixels[grid_start + offset .. grid_end];
         const src = source[grid_start .. grid_start + retained];
-        if (source.ptr == job.pixels.ptr)
+        if (source.ptr == pixels.ptr)
             @memmove(dst, src)
         else
             Renderer.copyPixels(dst, src);
@@ -699,7 +731,7 @@ test "unchanged dirty rows report no damage" {
     const pixels = try alloc.alloc(u32, @as(usize, width) * height);
     defer alloc.free(pixels);
     const job: Job = .{
-        .pixels = pixels,
+        .pixels = .{ .rgba8 = pixels },
         .source_pixels = null,
         .width = width,
         .height = height,
@@ -745,8 +777,8 @@ test "repair previous frame" {
     var target = [_]u32{ 1, 2, 3, 4 };
     const source = [_]u32{ 5, 6, 7, 8 };
     const base: Job = .{
-        .pixels = &target,
-        .source_pixels = &source,
+        .pixels = .{ .rgba8 = &target },
+        .source_pixels = .{ .rgba8 = &source },
         .width = 2,
         .height = 2,
         .grid_x = 0,
@@ -817,7 +849,7 @@ test "scroll previous frame in place and from distinct source" {
         12, 13, 14,
     };
     var job: Job = .{
-        .pixels = &pixels,
+        .pixels = .{ .rgba8 = &pixels },
         .source_pixels = null,
         .width = 3,
         .height = 5,
@@ -859,7 +891,7 @@ test "scroll previous frame in place and from distinct source" {
     };
     @memset(&pixels, 99);
     job.age = 0;
-    job.source_pixels = &source;
+    job.source_pixels = .{ .rgba8 = &source };
     try std.testing.expect(scrollFromPreviousFrame(job, -1, 1));
     try std.testing.expectEqualSlices(u32, &.{ 23, 24, 25, 26, 27, 28 }, pixels[6..12]);
     try std.testing.expectEqualSlices(u32, &.{ 99, 99, 99 }, pixels[3..6]);

--- a/src/Config.zig
+++ b/src/Config.zig
@@ -127,6 +127,11 @@ background_opacity: u8 = 255,
 background_blur: bool = true,
 /// Whether background opacity also applies to explicit cell backgrounds.
 background_opacity_cells: bool = false,
+/// Blend text in linear light on 16-bit wl_shm buffers tagged as linear
+/// sRGB (foot's gamma-correct-blending). Requires a compositor implementing
+/// wp-color-manager-v1 with ext_linear/sRGB and the ABGR16161616 shm format;
+/// unsupported compositors fall back to the regular 8-bit pipeline.
+gamma_correct_blending: bool = false,
 
 theme: ?Theme = null,
 light_theme_overrides: ?ThemeOverrides = null,
@@ -273,6 +278,13 @@ pub fn set(self: *Config, arena: std.mem.Allocator, key: []const u8, value: []co
             return error.InvalidValue;
     } else if (std.mem.eql(u8, key, "background-opacity-cells")) {
         self.background_opacity_cells = if (std.mem.eql(u8, value, "true"))
+            true
+        else if (std.mem.eql(u8, value, "false"))
+            false
+        else
+            return error.InvalidValue;
+    } else if (std.mem.eql(u8, key, "gamma-correct-blending")) {
+        self.gamma_correct_blending = if (std.mem.eql(u8, value, "true"))
             true
         else if (std.mem.eql(u8, value, "false"))
             false
@@ -542,6 +554,7 @@ test "defaults" {
     try std.testing.expectEqual(@as(u8, 255), config.background_opacity);
     try std.testing.expect(config.background_blur);
     try std.testing.expect(!config.background_opacity_cells);
+    try std.testing.expect(!config.gamma_correct_blending);
     try std.testing.expectEqual(@as(?Theme, null), config.theme);
     try std.testing.expectEqual(@as(?ThemeOverrides, null), config.light_theme_overrides);
     try std.testing.expectEqual(@as(?ThemeOverrides, null), config.dark_theme_overrides);
@@ -583,6 +596,7 @@ test "parse config" {
         \\background-opacity = 0.8
         \\background-blur = false
         \\background-opacity-cells = true
+        \\gamma-correct-blending = true
         \\background = #1a1b26
         \\foreground = c0caf5
         \\cursor-color = #aabbcc
@@ -616,6 +630,7 @@ test "parse config" {
     try std.testing.expectEqual(@as(u8, 204), config.background_opacity);
     try std.testing.expect(!config.background_blur);
     try std.testing.expect(config.background_opacity_cells);
+    try std.testing.expect(config.gamma_correct_blending);
     try std.testing.expectEqual(vt.color.RGB{ .r = 0x1a, .g = 0x1b, .b = 0x26 }, config.background.?);
     try std.testing.expectEqual(vt.color.RGB{ .r = 0xc0, .g = 0xca, .b = 0xf5 }, config.foreground.?);
     try std.testing.expectEqual(TerminalColor{ .rgb = .{ .r = 0xaa, .g = 0xbb, .b = 0xcc } }, config.cursor_color.?);

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -43,6 +43,30 @@ const blendRgb = pixel_raster.blendRgb;
 const blitGlyph = pixel_raster.blitGlyph;
 const fillRect = pixel_raster.fillRect;
 
+/// Raster primitives for a framebuffer pixel type: 8-bit sRGB ARGB8888
+/// (u32), or 16-bit linear ABGR16161616 (u64) when gamma-correct blending
+/// renders into linear-light buffers. The pixel slice's child type selects
+/// the pipeline, so a single Renderer serves both buffer formats.
+fn Raster(comptime P: type) type {
+    return switch (P) {
+        u32 => pixel_raster,
+        u64 => pixel_raster.linear,
+        else => @compileError("unsupported framebuffer pixel type"),
+    };
+}
+
+/// Element type of a framebuffer slice; tests often pass a pointer to an
+/// array instead of a slice.
+fn PixelChild(comptime T: type) type {
+    const info = @typeInfo(T).pointer;
+    return if (info.size == .slice) info.child else std.meta.Child(info.child);
+}
+
+/// A framebuffer pixel slice in the window's current buffer format:
+/// 8-bit sRGB ARGB8888, or 16-bit linear ABGR16161616 when gamma-correct
+/// blending is active.
+pub const PixelBuffer = @import("pixel_buffer.zig").PixelBuffer;
+
 alloc: std.mem.Allocator,
 font: *Font,
 text_shaper: TextShaper,
@@ -248,7 +272,7 @@ fn pixelStride(self: *const Renderer, width: u31) u31 {
     return stride;
 }
 
-fn pixelBufferFits(pixels: []const u32, stride: u31, width: u31, height: u31) bool {
+fn pixelBufferFits(pixels: anytype, stride: u31, width: u31, height: u31) bool {
     if (width == 0 or height == 0) return true;
     return pixels.len >= @as(usize, height - 1) * stride + width;
 }
@@ -257,14 +281,16 @@ fn pixelBufferFits(pixels: []const u32, stride: u31, width: u31, height: u31) bo
 pub fn render(
     self: *Renderer,
     state: *const vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     std.debug.assert(pixelBufferFits(pixels, self.pixelStride(width), width, height));
 
     if (state.rows == 0 or state.cols == 0) {
-        fillRect(pixels, self.pixelStride(width), width, height, 0, 0, width, height, self.backgroundPixel(state.colors.background));
+        pr.fillRect(pixels, self.pixelStride(width), width, height, 0, 0, width, height, self.backgroundPixel(P, state.colors.background));
         if (self.track_cell_damage) try self.snapshotCellFingerprints(state);
         return;
     }
@@ -289,7 +315,7 @@ pub fn render(
     // grid row remains.
     const grid_bottom = @as(usize, state.rows) * self.font.cell_height;
     if (grid_bottom < height) {
-        fillRect(
+        pr.fillRect(
             pixels,
             self.pixelStride(width),
             width,
@@ -298,7 +324,7 @@ pub fn render(
             @intCast(grid_bottom),
             width,
             height - @as(u31, @intCast(grid_bottom)),
-            self.backgroundPixel(state.colors.background),
+            self.backgroundPixel(P, state.colors.background),
         );
     }
     if (self.track_cell_damage) try self.snapshotCellFingerprints(state);
@@ -311,10 +337,12 @@ pub fn renderWithKittyItems(
     self: *Renderer,
     state: *const vt.RenderState,
     items: []const KittyRenderItem,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     std.debug.assert(pixelBufferFits(pixels, self.pixelStride(width), width, height));
     self.kitty_frame +%= 1;
 
@@ -333,7 +361,7 @@ pub fn renderWithKittyItems(
         }
     }
 
-    fillRect(pixels, self.pixelStride(width), width, height, 0, 0, width, height, self.backgroundPixel(state.colors.background));
+    pr.fillRect(pixels, self.pixelStride(width), width, height, 0, 0, width, height, self.backgroundPixel(P, state.colors.background));
     if (state.rows == 0 or state.cols == 0) {
         if (self.track_cell_damage) try self.snapshotCellFingerprints(state);
         return;
@@ -393,7 +421,7 @@ pub fn renderWithKittyItems(
 pub fn renderDirty(
     self: *Renderer,
     state: *vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
@@ -620,12 +648,14 @@ pub fn shiftCellState(self: *Renderer, rows: usize, cols: usize, shift_rows: isi
 pub fn renderPreedit(
     self: *Renderer,
     state: *const vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     text: []const u8,
 ) !void {
     if (text.len == 0) return;
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     const cursor = state.cursor.viewport orelse return;
     if (cursor.y >= state.rows) return;
 
@@ -646,7 +676,7 @@ pub fn renderPreedit(
         const clipped_span: u31 = @min(span, state.cols - x);
         const cp = cps[i - cluster.len];
 
-        fillRect(
+        pr.fillRect(
             pixels,
             self.pixelStride(width),
             width,
@@ -655,7 +685,7 @@ pub fn renderPreedit(
             y * self.font.cell_height,
             clipped_span * self.font.cell_width,
             self.font.cell_height,
-            self.backgroundPixel(state.colors.background),
+            self.backgroundPixel(P, state.colors.background),
         );
 
         const face_idx = self.font.faceForCodepoint(self.alloc, cp);
@@ -663,7 +693,7 @@ pub fn renderPreedit(
         const glyph_idx = c.FT_Get_Char_Index(face.ft_face, cp);
         if (glyph_idx != 0) {
             const g = try face.glyph(self.alloc, glyph_idx, @intCast(@min(span, 2)), glyph_constraints.isSymbol(cp));
-            blitGlyph(
+            pr.blitGlyph(
                 pixels,
                 self.pixelStride(width),
                 width,
@@ -671,12 +701,12 @@ pub fn renderPreedit(
                 g,
                 @as(i32, x) * self.font.cell_width + g.bearing_x,
                 baseline_y - g.bearing_y,
-                argb(state.colors.foreground),
+                pr.argb(state.colors.foreground),
                 false,
                 self.glyph_clip_x,
             );
         }
-        try self.blitDecoration(.underline, x, y, argb(state.colors.foreground), pixels, width, height);
+        try self.blitDecoration(.underline, x, y, pixels, width, height, pr.argb(state.colors.foreground));
         x += span;
     }
 }
@@ -684,7 +714,7 @@ pub fn renderPreedit(
 pub fn renderLinkHint(
     self: *Renderer,
     state: *const vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     uri: []const u8,
@@ -703,7 +733,7 @@ pub fn renderLinkHint(
 pub fn renderSearch(
     self: *Renderer,
     state: *const vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     text: []const u8,
@@ -726,18 +756,20 @@ pub fn renderSearch(
 pub fn renderScrollbarThumb(
     self: *Renderer,
     state: *const vt.RenderState,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     thumb: ScrollbarThumb,
 ) void {
-    blendCapsule(
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
+    pr.blendCapsule(
         pixels,
         self.pixelStride(width),
         width,
         height,
         thumb,
-        argb(state.colors.foreground),
+        pr.argb(state.colors.foreground),
     );
 }
 
@@ -782,7 +814,7 @@ fn overlayText(cps: []const u21, max_width: u31, suffix: bool) OverlayText {
 
 fn renderTextOverlay(
     self: *Renderer,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     text: []const u8,
@@ -791,6 +823,8 @@ fn renderTextOverlay(
     fg: vt.color.RGB,
 ) !void {
     if (text.len == 0 or width == 0 or height < self.font.cell_height) return;
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
 
     const cols: u31 = @max(1, width / self.font.cell_width);
     const padding: u31 = @intFromBool(cols > 2);
@@ -802,7 +836,7 @@ fn renderTextOverlay(
     const y: u31 = if (position == .top_right) 0 else height - self.font.cell_height;
     const baseline_y: i32 = @as(i32, @intCast(y)) + self.font.baseline;
 
-    fillRect(
+    pr.fillRect(
         pixels,
         self.pixelStride(width),
         width,
@@ -811,7 +845,7 @@ fn renderTextOverlay(
         y,
         box_width * self.font.cell_width,
         self.font.cell_height,
-        argb(bg),
+        pr.argb(bg),
     );
 
     var x = box_x + padding;
@@ -830,7 +864,7 @@ fn renderTextOverlay(
         const glyph_idx = c.FT_Get_Char_Index(face.ft_face, cp);
         if (glyph_idx != 0) {
             const g = try face.glyph(self.alloc, glyph_idx, @intCast(@min(span, 2)), glyph_constraints.isSymbol(cp));
-            blitGlyph(
+            pr.blitGlyph(
                 pixels,
                 self.pixelStride(width),
                 width,
@@ -838,7 +872,7 @@ fn renderTextOverlay(
                 g,
                 @as(i32, x) * self.font.cell_width + g.bearing_x,
                 baseline_y - g.bearing_y,
-                argb(fg),
+                pr.argb(fg),
                 false,
                 self.glyph_clip_x,
             );
@@ -850,7 +884,7 @@ fn renderTextOverlay(
 fn renderKittyItems(
     self: *Renderer,
     items: []const KittyRenderItem,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     layer: KittyGraphicsLayer,
@@ -878,7 +912,7 @@ const KittyGraphicsLayer = enum {
 
 fn renderKittyPlacement(
     self: *Renderer,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     image: KittyImage,
@@ -985,7 +1019,7 @@ fn makeKittyScaleRoom(self: *Renderer, new_bytes: usize) bool {
 /// bytes: one pass per row with the destination rect clipped up front,
 /// converting from the image's wire format as it writes.
 fn blitKittyUnscaled(
-    pixels: []u32,
+    pixels: anytype,
     stride: u31,
     width: u31,
     height: u31,
@@ -994,6 +1028,8 @@ fn blitKittyUnscaled(
     dest_x: i64,
     dest_y: i64,
 ) void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     std.debug.assert(viewport.pixel_width == viewport.source_width);
     std.debug.assert(viewport.pixel_height == viewport.source_height);
 
@@ -1031,36 +1067,42 @@ fn blitKittyUnscaled(
                 const s = src[i * 4 ..][0..4];
                 switch (s[3]) {
                     0 => {},
-                    0xff => px.* = 0xff000000 |
-                        (@as(u32, s[0]) << 16) | (@as(u32, s[1]) << 8) | s[2],
-                    else => px.* = blendPixel(px.*, s),
+                    0xff => px.* = pr.expandedArgb(s[0], s[1], s[2]),
+                    else => px.* = pr.blendPixel(px.*, s),
                 }
             },
             .gray => for (dst, 0..) |*px, i| {
-                const gray: u32 = src[i];
-                px.* = 0xff000000 | (gray << 16) | (gray << 8) | gray;
+                px.* = pr.expandedArgb(src[i], src[i], src[i]);
             },
             .gray_alpha => for (dst, 0..) |*px, i| {
                 const gray = src[i * 2];
-                px.* = blendPixel(px.*, &.{ gray, gray, gray, src[i * 2 + 1] });
+                px.* = pr.blendPixel(px.*, &.{ gray, gray, gray, src[i * 2 + 1] });
             },
             .png => unreachable,
         }
     }
 }
 
-/// Expand packed RGB into the framebuffer's opaque ARGB8888 format.
+/// Expand packed RGB into the framebuffer's opaque pixel format.
 /// Kitty video frames are normally RGB and cover millions of pixels,
-/// so shuffle four pixels at a time instead of assembling each u32
-/// channel by channel. ARGB8888 is BGRA in memory only on little-endian
-/// targets; keep the channel-explicit fallback everywhere else.
-fn copyOpaqueRgbSpan(noalias dst: []u32, noalias src: []const u8) void {
+/// so the 8-bit path shuffles four pixels at a time instead of assembling
+/// each u32 channel by channel. ARGB8888 is BGRA in memory only on
+/// little-endian targets; keep the channel-explicit fallback everywhere
+/// else. The 16-bit linear path expands bytes without sRGB decoding, the
+/// same tradeoff foot's pixman pipeline makes.
+fn copyOpaqueRgbSpan(noalias dst: anytype, noalias src: []const u8) void {
+    const P = std.meta.Child(@TypeOf(dst));
     std.debug.assert(src.len == dst.len * 3);
-    if (comptime builtin.target.cpu.arch.endian() != .little) {
+    if (P == u64) {
         for (dst, 0..) |*pixel, i| {
             const rgb = src[i * 3 ..][0..3];
-            pixel.* = 0xff000000 |
-                (@as(u32, rgb[0]) << 16) | (@as(u32, rgb[1]) << 8) | rgb[2];
+            pixel.* = pixel_raster.linear.expandedArgb(rgb[0], rgb[1], rgb[2]);
+        }
+        return;
+    } else if (comptime builtin.target.cpu.arch.endian() != .little) {
+        for (dst, 0..) |*pixel, i| {
+            const rgb = src[i * 3 ..][0..3];
+            pixel.* = pixel_raster.expandedArgb(rgb[0], rgb[1], rgb[2]);
         }
         return;
     }
@@ -1170,7 +1212,7 @@ fn resizeRgba(
 }
 
 fn blendRgba(
-    pixels: []u32,
+    pixels: anytype,
     stride: u31,
     width: u31,
     height: u31,
@@ -1180,6 +1222,8 @@ fn blendRgba(
     dest_x: i64,
     dest_y: i64,
 ) void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     for (0..image_height) |src_y| {
         const y = dest_y + @as(i64, @intCast(src_y));
         if (y < 0 or y >= height) continue;
@@ -1194,14 +1238,15 @@ fn blendRgba(
 
             const dst_idx = @as(usize, @intCast(y)) * stride + @as(usize, @intCast(x));
             if (alpha == 0xff) {
-                pixels[dst_idx] = 0xff000000 |
-                    (@as(u32, rgba[src_offset + 0]) << 16) |
-                    (@as(u32, rgba[src_offset + 1]) << 8) |
-                    @as(u32, rgba[src_offset + 2]);
+                pixels[dst_idx] = pr.expandedArgb(
+                    rgba[src_offset + 0],
+                    rgba[src_offset + 1],
+                    rgba[src_offset + 2],
+                );
                 continue;
             }
 
-            pixels[dst_idx] = blendPixel(pixels[dst_idx], rgba[src_offset..][0..4]);
+            pixels[dst_idx] = pr.blendPixel(pixels[dst_idx], rgba[src_offset..][0..4]);
         }
     }
 }
@@ -1212,7 +1257,7 @@ fn renderRow(
     cells: std.MultiArrayList(vt.RenderState.Cell).Slice,
     selection: ?[2]vt.size.CellCountInt,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
@@ -1227,7 +1272,7 @@ fn renderRowCells(
     selection: ?[2]vt.size.CellCountInt,
     cell_range: CellRange,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
@@ -1289,7 +1334,7 @@ fn prepareRow(
     cells: std.MultiArrayList(vt.RenderState.Cell).Slice,
     selection: ?[2]vt.size.CellCountInt,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     backgrounds: Backgrounds,
@@ -1314,11 +1359,13 @@ fn prepareRowCells(
     selection: ?[2]vt.size.CellCountInt,
     cell_range: CellRange,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
     backgrounds: Backgrounds,
 ) !void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     const font = self.font;
     const colors = &state.colors;
     const raws = cells.items(.raw);
@@ -1408,16 +1455,16 @@ fn prepareRowCells(
         self.fg_scratch.items[x] = fg;
         self.reverse_scratch.items[x] = reverse_color_glyph;
         if (backgrounds != .none and x >= cell_range.start and x < cell_range.end) {
-            const color: ?u32 = if (dim_search_bg) color: {
+            const color: ?P = if (dim_search_bg) color: {
                 const mixed = blendRgb(self.search_bg, bg orelse colors.background, search_match_alpha);
                 break :color if (bg == null or background_uses_alpha)
-                    self.backgroundPixel(mixed)
+                    self.backgroundPixel(P, mixed)
                 else
-                    argb(mixed);
+                    pr.argb(mixed);
             } else if (bg) |bg_color|
-                if (background_uses_alpha) self.backgroundPixel(bg_color) else argb(bg_color)
+                if (background_uses_alpha) self.backgroundPixel(P, bg_color) else pr.argb(bg_color)
             else switch (backgrounds) {
-                .all => self.backgroundPixel(colors.background),
+                .all => self.backgroundPixel(P, colors.background),
                 else => null,
             };
             if (color) |pixel| {
@@ -1441,7 +1488,7 @@ fn prepareRowCells(
     if (backgrounds == .all and cell_range.end == cols) {
         const margin_start: u31 = cols * font.cell_width;
         if (margin_start < width) {
-            const color = self.backgroundPixel(colors.background);
+            const color = self.backgroundPixel(P, colors.background);
             if (bg_run.active and color == bg_run.color) {
                 bg_run.end_px = width;
             } else {
@@ -1468,7 +1515,7 @@ fn prepareRowCells(
             const clipped_bottom: u31 = @intCast(std.math.clamp(bottom, 0, height));
             if (clipped_bottom > clipped_top) {
                 const cursor_width = font.cell_width * glyph_constraints.cellSpan(raws[cx]);
-                fillRect(
+                pr.fillRect(
                     pixels,
                     self.pixelStride(width),
                     width,
@@ -1477,23 +1524,26 @@ fn prepareRowCells(
                     clipped_top,
                     cursor_width,
                     clipped_bottom - clipped_top,
-                    argb(self.cursorFill(colors, cell.fg, cell.bg)),
+                    pr.argb(self.cursorFill(colors, cell.fg, cell.bg)),
                 );
             }
         }
     }
 }
 
-/// A pending run of adjacent equal-color cell backgrounds.
+/// A pending run of adjacent equal-color cell backgrounds. The color is
+/// stored widened to u64 so the same struct serves 8-bit and 16-bit
+/// framebuffers.
 const BgRun = struct {
     active: bool = false,
-    color: u32 = 0,
+    color: u64 = 0,
     start_px: u31 = 0,
     end_px: u31 = 0,
 
-    fn flush(run: *BgRun, pixels: []u32, stride: u31, buf_width: u31, buf_height: u31, y_px: u31, h: u31) void {
+    fn flush(run: *BgRun, pixels: anytype, stride: u31, buf_width: u31, buf_height: u31, y_px: u31, h: u31) void {
         if (!run.active) return;
-        fillRect(pixels, stride, buf_width, buf_height, run.start_px, y_px, run.end_px - run.start_px, h, run.color);
+        const pr = Raster(PixelChild(@TypeOf(pixels)));
+        pr.fillRect(pixels, stride, buf_width, buf_height, run.start_px, y_px, run.end_px - run.start_px, h, @intCast(run.color));
         run.active = false;
     }
 };
@@ -1503,7 +1553,7 @@ fn renderRowForeground(
     state: *const vt.RenderState,
     cells: std.MultiArrayList(vt.RenderState.Cell).Slice,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
@@ -1524,10 +1574,12 @@ fn renderRowForegroundCells(
     cells: std.MultiArrayList(vt.RenderState.Cell).Slice,
     cell_range: CellRange,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     const colors = &state.colors;
     const raws = cells.items(.raw);
     const styles = cells.items(.style);
@@ -1595,7 +1647,7 @@ fn renderRowForegroundCells(
 
         const cell_x: u31 = @intCast(dx);
         if (show_hyperlink) {
-            try self.blitDecoration(.underline, cell_x, y, argb(self.fg_scratch.items[dx]), pixels, width, height);
+            try self.blitDecoration(.underline, cell_x, y, pixels, width, height, pr.argb(self.fg_scratch.items[dx]));
         }
         if (underline) |u| {
             const kind: @import("sprite.zig").Decoration = switch (u) {
@@ -1607,15 +1659,15 @@ fn renderRowForegroundCells(
                 .none => unreachable,
             };
             const color = style.underlineColor(&colors.palette) orelse self.fg_scratch.items[dx];
-            try self.blitDecoration(kind, cell_x, y, argb(color), pixels, width, height);
+            try self.blitDecoration(kind, cell_x, y, pixels, width, height, pr.argb(color));
         }
         if (style.flags.strikethrough) {
             const color = self.fg_scratch.items[dx];
-            try self.blitDecoration(.strikethrough, cell_x, y, argb(color), pixels, width, height);
+            try self.blitDecoration(.strikethrough, cell_x, y, pixels, width, height, pr.argb(color));
         }
         if (style.flags.overline) {
             const color = self.fg_scratch.items[dx];
-            try self.blitDecoration(.overline, cell_x, y, argb(color), pixels, width, height);
+            try self.blitDecoration(.overline, cell_x, y, pixels, width, height, pr.argb(color));
         }
     }
 
@@ -1635,7 +1687,7 @@ fn renderRowForegroundCells(
         if (kind) |k| {
             const cell = cursorCellRgb(state.cursor.style, &state.cursor.cell, colors);
             const color = self.cursorFill(colors, cell.fg, cell.bg);
-            try self.blitDecoration(k, cx, y, argb(color), pixels, width, height);
+            try self.blitDecoration(k, cx, y, pixels, width, height, pr.argb(color));
         }
     }
 }
@@ -1652,16 +1704,17 @@ fn blitDecoration(
     kind: @import("sprite.zig").Decoration,
     cell_x: u31,
     y: u31,
-    color: u32,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
+    color: PixelChild(@TypeOf(pixels)),
 ) !void {
+    const pr = Raster(PixelChild(@TypeOf(pixels)));
     const font = self.font;
     const g = try font.decorationGlyph(self.alloc, kind);
     self.noteOverhang(@as(i32, font.baseline) - g.bearing_y, g.height);
     const baseline_y: i32 = @as(i32, y) * font.cell_height + font.baseline;
-    blitGlyph(
+    pr.blitGlyph(
         pixels,
         self.pixelStride(width),
         width,
@@ -1686,11 +1739,13 @@ fn drawRun(
     end: u31,
     cols: u31,
     y: u31,
-    pixels: []u32,
+    pixels: anytype,
     width: u31,
     height: u31,
 ) !void {
     if (start >= end) return;
+    const P = PixelChild(@TypeOf(pixels));
+    const pr = Raster(P);
     const font = self.font;
 
     // Sprite glyphs are drawn directly, one per cell: they never shape
@@ -1705,7 +1760,7 @@ fn drawRun(
             const cell_span: u2 = @intCast(@min(glyph_constraints.cellSpan(raw), 2));
             const g = try font.spriteGlyph(self.alloc, cp, cell_span);
             self.noteOverhang(@as(i32, font.baseline) - g.bearing_y, g.height);
-            blitGlyph(
+            pr.blitGlyph(
                 pixels,
                 self.pixelStride(width),
                 width,
@@ -1713,7 +1768,7 @@ fn drawRun(
                 g,
                 @as(i32, @intCast(x)) * font.cell_width + g.bearing_x,
                 baseline_y - g.bearing_y,
-                argb(self.fg_scratch.items[x]),
+                pr.argb(self.fg_scratch.items[x]),
                 false,
                 self.glyph_clip_x,
             );
@@ -1775,7 +1830,7 @@ fn drawRun(
             else => |e| return e,
         };
         self.noteOverhang(@as(i32, font.baseline) - sg.y_offset - g.bearing_y, g.height);
-        blitGlyph(
+        pr.blitGlyph(
             pixels,
             self.pixelStride(width),
             width,
@@ -1783,7 +1838,7 @@ fn drawRun(
             g,
             pen_x + sg.x_offset + g.bearing_x,
             baseline_y - sg.y_offset - g.bearing_y,
-            argb(self.fg_scratch.items[cluster]),
+            pr.argb(self.fg_scratch.items[cluster]),
             self.reverse_scratch.items[cluster],
             self.glyph_clip_x,
         );
@@ -1803,13 +1858,15 @@ fn overlayCodepoints(self: *Renderer, text: []const u8) ![]const u21 {
 /// the read-for-ownership of every destination cache line (about a
 /// third of the bus traffic) and keep the copy from evicting the
 /// render working set.
-pub fn copyPixels(noalias dst: []u32, noalias src: []const u32) void {
+pub fn copyPixels(noalias dst: anytype, noalias src: anytype) void {
     return pixel_copy.copyPixels(dst, src);
 }
 
-/// Pack a background color in wl_shm's premultiplied ARGB8888 form.
-pub fn backgroundPixel(self: *const Renderer, rgb: vt.color.RGB) u32 {
-    return pixel_raster.premultipliedArgb(rgb, self.background_alpha);
+/// Pack a background color in the framebuffer's premultiplied form for
+/// pixel type P: sRGB ARGB8888 (u32), or linear ABGR16161616 (u64) when
+/// gamma-correct blending renders into 16-bit buffers.
+pub fn backgroundPixel(self: *const Renderer, comptime P: type, rgb: vt.color.RGB) P {
+    return Raster(P).premultipliedArgb(rgb, self.background_alpha);
 }
 
 test "kitty unscaled blit converts rgb and clips" {
@@ -2626,12 +2683,12 @@ test "background opacity cells controls explicit cell backgrounds" {
     const explicit_bg = pixels[@as(usize, y) * width + font.cell_width / 2];
     const default_bg = pixels[@as(usize, y) * width + font.cell_width + font.cell_width / 2];
     try std.testing.expectEqual(argb(state.colors.palette[1]), explicit_bg);
-    try std.testing.expectEqual(renderer.backgroundPixel(state.colors.background), default_bg);
+    try std.testing.expectEqual(renderer.backgroundPixel(u32, state.colors.background), default_bg);
 
     renderer.background_alpha_cells = true;
     try renderer.render(&state, pixels, width, height);
     const faded_explicit_bg = pixels[@as(usize, y) * width + font.cell_width / 2];
-    try std.testing.expectEqual(renderer.backgroundPixel(state.colors.palette[1]), faded_explicit_bg);
+    try std.testing.expectEqual(renderer.backgroundPixel(u32, state.colors.palette[1]), faded_explicit_bg);
 }
 
 test "render rectangular selection spans" {
@@ -2681,7 +2738,7 @@ test "render rectangular selection spans" {
     try renderer.render(&state, pixels, width, height);
 
     const selected = argb(selection_bg);
-    const background = renderer.backgroundPixel(state.colors.background);
+    const background = renderer.backgroundPixel(u32, state.colors.background);
     for (0..5) |y| {
         for (0..8) |x| {
             const px = (y * font.cell_height + font.cell_height / 2) * width +
@@ -3260,7 +3317,7 @@ test "unselected search match tints its existing background" {
     defer alloc.free(pixels);
     try renderer.render(&state, pixels, width, height);
 
-    const expected = renderer.backgroundPixel(blendRgb(
+    const expected = renderer.backgroundPixel(u32, blendRgb(
         renderer.search_bg,
         state.colors.background,
         search_match_alpha,

--- a/src/ShmBuffer.zig
+++ b/src/ShmBuffer.zig
@@ -7,6 +7,7 @@ const linux = std.os.linux;
 const posix = std.posix;
 const wayland = @import("wayland");
 const wl = wayland.client.wl;
+const PixelBuffer = @import("pixel_buffer.zig").PixelBuffer;
 
 wl_buffer: *wl.Buffer,
 pool: *wl.ShmPool,
@@ -24,6 +25,17 @@ frame: u64,
 pub const Format = enum {
     xrgb8888,
     argb8888,
+    /// 16-bit-per-channel premultiplied linear sRGB for gamma-correct
+    /// blending; the surface must carry a matching wp-color-manager-v1
+    /// image description.
+    abgr16161616,
+
+    fn bytesPerPixel(format: Format) usize {
+        return switch (format) {
+            .xrgb8888, .argb8888 => 4,
+            .abgr16161616 => 8,
+        };
+    }
 };
 
 pub fn create(
@@ -34,7 +46,7 @@ pub fn create(
     format: Format,
 ) !*ShmBuffer {
     std.debug.assert(width > 0 and height > 0);
-    const dimensions = try bufferDimensions(width, height);
+    const dimensions = try bufferDimensions(width, height, format);
     const capacity = try grownBufferCapacity(0, dimensions.size);
 
     const fd = try posix.memfd_create("monstar-shm", linux.MFD.CLOEXEC);
@@ -76,7 +88,7 @@ pub fn create(
 pub fn reshape(self: *ShmBuffer, width: u31, height: u31, format: Format) !void {
     std.debug.assert(!self.busy and !self.rendering);
     std.debug.assert(width > 0 and height > 0);
-    const dimensions = try bufferDimensions(width, height);
+    const dimensions = try bufferDimensions(width, height, format);
     if (dimensions.size > self.data.len) {
         const capacity = try grownBufferCapacity(self.data.len, dimensions.size);
         if (linux.errno(linux.ftruncate(self.fd, @intCast(capacity))) != .SUCCESS) return error.ShmFailed;
@@ -111,9 +123,17 @@ pub fn destroy(self: *ShmBuffer, alloc: std.mem.Allocator) void {
     alloc.destroy(self);
 }
 
-pub fn pixels(self: *ShmBuffer) []u32 {
+/// The buffer's pixels in the format's natural element type.
+pub fn pixels(self: *ShmBuffer) PixelBuffer {
     const pixel_count = @as(usize, self.width) * @as(usize, self.height);
-    return @alignCast(std.mem.bytesAsSlice(u32, self.data)[0..pixel_count]);
+    return switch (self.format) {
+        .xrgb8888, .argb8888 => .{
+            .rgba8 = @alignCast(std.mem.bytesAsSlice(u32, self.data)[0..pixel_count]),
+        },
+        .abgr16161616 => .{
+            .rgba16 = @alignCast(std.mem.bytesAsSlice(u64, self.data)[0..pixel_count]),
+        },
+    };
 }
 
 fn bufferListener(_: *wl.Buffer, event: wl.Buffer.Event, self: *ShmBuffer) void {
@@ -127,8 +147,8 @@ const BufferDimensions = struct {
     size: usize,
 };
 
-fn bufferDimensions(width: u31, height: u31) !BufferDimensions {
-    const stride = @as(usize, width) * @sizeOf(u32);
+fn bufferDimensions(width: u31, height: u31, format: Format) !BufferDimensions {
+    const stride = @as(usize, width) * format.bytesPerPixel();
     const size = stride * @as(usize, height);
     if (stride > std.math.maxInt(i32) or size > std.math.maxInt(i32)) return error.ShmBufferTooLarge;
     return .{ .stride = @intCast(stride), .size = size };
@@ -147,6 +167,7 @@ fn shmFormat(format: Format) wl.Shm.Format {
     return switch (format) {
         .xrgb8888 => .xrgb8888,
         .argb8888 => .argb8888,
+        .abgr16161616 => .abgr16161616,
     };
 }
 
@@ -158,4 +179,11 @@ test "SHM buffer capacity grows geometrically and remains page aligned" {
     const grown = try grownBufferCapacity(initial, initial + 1);
     try std.testing.expect(grown >= initial + initial / 2);
     try std.testing.expectEqual(@as(usize, 0), grown % std.heap.page_size_min);
+}
+
+test "16-bit buffers double the stride" {
+    const rgba8 = try bufferDimensions(100, 50, .argb8888);
+    const rgba16 = try bufferDimensions(100, 50, .abgr16161616);
+    try std.testing.expectEqual(rgba8.stride * 2, rgba16.stride);
+    try std.testing.expectEqual(rgba8.size * 2, rgba16.size);
 }

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -280,10 +280,6 @@ pub fn create(
     errdefer globals.deinit();
     registry.setListener(*Globals, registryListener, globals);
     if (display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
-    // Events emitted on bind (wl_shm formats, wp_color_manager_v1
-    // capabilities) trail the initial sync; collect them with a second
-    // roundtrip before the window state reads them.
-    if (display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
 
     const compositor = globals.compositor orelse return error.NoWlCompositor;
     const shm = globals.shm orelse return error.NoWlShm;
@@ -397,10 +393,9 @@ pub fn create(
         .background_effect = background_effect,
         .color_manager = globals.color_manager,
         .color_surface = null,
-        .gamma_correct_supported = globals.color_manager != null and
-            globals.cm_feature_parametric and globals.cm_intent_perceptual and
-            globals.cm_tf_ext_linear and globals.cm_primaries_srgb and
-            globals.shm_abgr16161616,
+        // Computed after the post-bind roundtrip below; the capability
+        // events it reads have not arrived yet at this point.
+        .gamma_correct_supported = false,
         .gamma_correct = false,
         .seat = globals.seat,
         .keyboard = null,
@@ -468,6 +463,18 @@ pub fn create(
     surface.setListener(*Window, surfaceListener, self);
     xdg_surface.setListener(*Window, xdgSurfaceListener, self);
     toplevel.setListener(*Window, toplevelListener, self);
+
+    // Events emitted on bind (seat capabilities, wl_shm formats,
+    // wp_color_manager_v1 capabilities) trail the initial sync. Collect
+    // them with a second roundtrip now that every listener is installed:
+    // dispatching earlier would drop the seat capabilities that install
+    // the keyboard.
+    if (display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
+    self.gamma_correct_supported = globals.color_manager != null and
+        globals.cm_feature_parametric and globals.cm_intent_perceptual and
+        globals.cm_tf_ext_linear and globals.cm_primaries_srgb and
+        globals.shm_abgr16161616;
+
     surface.commit();
     // Send the initial commit now so the compositor can prepare configure
     // while the App finishes initialization. A full socket is harmless: the

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -4,6 +4,7 @@
 const Window = @This();
 
 const std = @import("std");
+const PixelBuffer = @import("pixel_buffer.zig").PixelBuffer;
 const ShmBuffer = @import("ShmBuffer.zig");
 const wayland = @import("wayland");
 const ext = wayland.client.ext;
@@ -33,6 +34,13 @@ system_bell: ?*xdg.SystemBellV1,
 toplevel_icon_manager: ?*xdg.ToplevelIconManagerV1,
 background_effect_manager: ?*ext.BackgroundEffectManagerV1,
 background_effect: ?*ext.BackgroundEffectSurfaceV1,
+color_manager: ?*wp.ColorManagerV1,
+color_surface: ?*wp.ColorManagementSurfaceV1,
+/// True when the compositor supports everything linear blending needs:
+/// wp-color-manager-v1 parametric descriptions (ext_linear transfer, sRGB
+/// primaries, perceptual intent) and 16-bit shm buffers.
+gamma_correct_supported: bool,
+gamma_correct: bool,
 seat: ?*wl.Seat,
 keyboard: ?*wl.Keyboard,
 pointer: ?*wl.Pointer,
@@ -63,6 +71,9 @@ buffers: std.ArrayList(*Buffer),
 /// Format new render buffers use. Old-format buffers may remain in the list
 /// while the compositor owns them; acquireBuffer retires them after release.
 buffer_format: BufferFormat,
+/// Format selection inputs; updateBufferFormat combines them (gamma-correct
+/// linear buffers take precedence over alpha).
+buffer_alpha: bool,
 /// Most recently committed buffer. Its memory may still be busy with the
 /// compositor, but wl_shm memory remains readable and can seed stale buffers.
 newest_buffer: ?*Buffer,
@@ -221,6 +232,15 @@ const Globals = struct {
     primary_manager: ?*zwp.PrimarySelectionDeviceManagerV1 = null,
     text_input_manager: ?*zwp.TextInputManagerV3 = null,
     decoration_manager: ?*zxdg.DecorationManagerV1 = null,
+    color_manager: ?*wp.ColorManagerV1 = null,
+    /// wp-color-manager-v1 capabilities reported before the done event.
+    cm_feature_parametric: bool = false,
+    cm_intent_perceptual: bool = false,
+    cm_tf_ext_linear: bool = false,
+    cm_primaries_srgb: bool = false,
+    /// Set once the compositor advertises the 16-bit shm format needed for
+    /// linear blending.
+    shm_abgr16161616: bool = false,
     outputs: std.ArrayList(*OutputState) = .empty,
 
     fn deinit(self: *Globals) void {
@@ -259,6 +279,10 @@ pub fn create(
     globals.* = .{ .alloc = alloc };
     errdefer globals.deinit();
     registry.setListener(*Globals, registryListener, globals);
+    if (display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
+    // Events emitted on bind (wl_shm formats, wp_color_manager_v1
+    // capabilities) trail the initial sync; collect them with a second
+    // roundtrip before the window state reads them.
     if (display.roundtrip() != .SUCCESS) return error.RoundtripFailed;
 
     const compositor = globals.compositor orelse return error.NoWlCompositor;
@@ -371,6 +395,13 @@ pub fn create(
         .toplevel_icon_manager = globals.toplevel_icon_manager,
         .background_effect_manager = globals.background_effect_manager,
         .background_effect = background_effect,
+        .color_manager = globals.color_manager,
+        .color_surface = null,
+        .gamma_correct_supported = globals.color_manager != null and
+            globals.cm_feature_parametric and globals.cm_intent_perceptual and
+            globals.cm_tf_ext_linear and globals.cm_primaries_srgb and
+            globals.shm_abgr16161616,
+        .gamma_correct = false,
         .seat = globals.seat,
         .keyboard = null,
         .pointer = null,
@@ -397,6 +428,7 @@ pub fn create(
         .toplevel = toplevel,
         .buffers = .empty,
         .buffer_format = .xrgb8888,
+        .buffer_alpha = false,
         .newest_buffer = null,
         // Zero until the first configure so the resize callback always
         // fires before the first draw.
@@ -480,9 +512,11 @@ pub fn destroy(self: *Window) void {
     if (self.system_bell) |bell| bell.destroy();
     if (self.toplevel_icon_manager) |manager| manager.destroy();
     if (self.background_effect) |effect| effect.destroy();
+    if (self.color_surface) |color_surface| color_surface.destroy();
     self.toplevel.destroy();
     self.xdg_surface.destroy();
     self.surface.destroy();
+    if (self.color_manager) |manager| manager.destroy();
     if (self.background_effect_manager) |manager| manager.destroy();
     self.wm_base.destroy();
     if (self.shm.getVersion() >= wl.Shm.release_since_version)
@@ -567,7 +601,70 @@ pub fn setCursorShape(self: *Window, shape: CursorShape) void {
 /// cannot be destroyed until wl_buffer.release, so they are retired lazily.
 /// After startup, callers must invalidate any in-flight or held frame.
 pub fn setBufferAlpha(self: *Window, enabled: bool) void {
-    const format: BufferFormat = if (enabled) .argb8888 else .xrgb8888;
+    if (enabled == self.buffer_alpha) return;
+    self.buffer_alpha = enabled;
+    self.updateBufferFormat();
+}
+
+/// Whether gamma-correct (linear) blending can be enabled: the compositor
+/// advertises wp-color-manager-v1 with parametric descriptions, the
+/// ext_linear transfer function, sRGB primaries, the perceptual render
+/// intent, and 16-bit shm buffers.
+pub fn gammaCorrectAvailable(self: *const Window) bool {
+    return self.gamma_correct_supported;
+}
+
+/// Enable or disable gamma-correct blending. Enabling tags the surface with
+/// a linear-light sRGB image description and switches render buffers to
+/// 16-bit; it is a no-op when gammaCorrectAvailable is false. Like
+/// setBufferAlpha, callers must invalidate any in-flight or held frame.
+pub fn setGammaCorrect(self: *Window, enabled: bool) void {
+    if (enabled == self.gamma_correct) return;
+    if (enabled and !self.gamma_correct_supported) return;
+    self.gamma_correct = enabled;
+    if (enabled) {
+        self.applyLinearImageDescription();
+    } else if (self.color_surface) |color_surface| {
+        color_surface.unsetImageDescription();
+    }
+    self.updateBufferFormat();
+}
+
+fn applyLinearImageDescription(self: *Window) void {
+    const manager = self.color_manager orelse {
+        self.gamma_correct = false;
+        return;
+    };
+    if (self.color_surface == null) {
+        self.color_surface = manager.getSurface(self.surface) catch |err| {
+            log.warn("color management surface setup failed: {}", .{err});
+            self.gamma_correct = false;
+            return;
+        };
+    }
+    const params = manager.createParametricCreator() catch |err| {
+        log.warn("parametric image description creator failed: {}", .{err});
+        self.gamma_correct = false;
+        return;
+    };
+    params.setTfNamed(.ext_linear);
+    params.setPrimariesNamed(.srgb);
+    const description = params.create() catch |err| {
+        log.warn("linear image description creation failed: {}", .{err});
+        self.gamma_correct = false;
+        return;
+    };
+    self.color_surface.?.setImageDescription(description, .perceptual);
+    description.destroy();
+}
+
+fn updateBufferFormat(self: *Window) void {
+    const format: BufferFormat = if (self.gamma_correct)
+        .abgr16161616
+    else if (self.buffer_alpha)
+        .argb8888
+    else
+        .xrgb8888;
     if (format == self.buffer_format) return;
     self.buffer_format = format;
     if (self.newest_buffer) |newest| {
@@ -793,11 +890,11 @@ pub const RenderTarget = struct {
     /// The checked-out buffer to pass to commitRender or cancelRender.
     buffer: *Buffer,
     /// Writable storage owned by `buffer`, valid until the checkout ends.
-    pixels: []u32,
+    pixels: PixelBuffer,
     /// Read-only contents of the newest compatible committed buffer, when
     /// available. It may alias `pixels`; the borrowed storage is valid until
     /// the checkout ends.
-    source_pixels: ?[]const u32,
+    source_pixels: ?PixelBuffer.Const,
     width: u31,
     height: u31,
     /// Buffer-age hint derived from commit-attempt bookkeeping, or 0 when no
@@ -823,10 +920,10 @@ fn beginRender(self: *Window, phys_width: u31, phys_height: u31) !RenderTarget {
     buffer.rendering = true;
     self.rendering_pending = true;
     const age: usize = if (buffer.frame == 0) 0 else @intCast(self.frame_counter + 1 - buffer.frame);
-    const source_pixels: ?[]const u32 = if (self.newest_buffer) |newest|
+    const source_pixels: ?PixelBuffer.Const = if (self.newest_buffer) |newest|
         if (newest.frame != 0 and newest.width == phys_width and newest.height == phys_height and
             newest.format == buffer.format)
-            newest.pixels()
+            newest.pixels().asConst()
         else
             null
     else
@@ -961,8 +1058,11 @@ fn registryListener(registry: *wl.Registry, event: wl.Registry.Event, globals: *
                 };
                 proxy.setListener(*OutputState, outputListener, output);
             } else if (std.mem.orderZ(u8, global.interface, wl.Shm.interface.name) == .eq) {
-                if (globals.shm == null)
-                    globals.shm = registry.bind(global.name, wl.Shm, @min(global.version, wl.Shm.generated_version)) catch return;
+                if (globals.shm == null) {
+                    const shm = registry.bind(global.name, wl.Shm, @min(global.version, wl.Shm.generated_version)) catch return;
+                    globals.shm = shm;
+                    shm.setListener(*Globals, shmListener, globals);
+                }
             } else if (std.mem.orderZ(u8, global.interface, xdg.WmBase.interface.name) == .eq) {
                 if (globals.wm_base == null)
                     globals.wm_base = registry.bind(global.name, xdg.WmBase, @min(global.version, xdg.WmBase.generated_version)) catch return;
@@ -1009,6 +1109,12 @@ fn registryListener(registry: *wl.Registry, event: wl.Registry.Event, globals: *
             } else if (std.mem.orderZ(u8, global.interface, zxdg.DecorationManagerV1.interface.name) == .eq) {
                 if (globals.decoration_manager == null)
                     globals.decoration_manager = registry.bind(global.name, zxdg.DecorationManagerV1, @min(global.version, zxdg.DecorationManagerV1.generated_version)) catch return;
+            } else if (std.mem.orderZ(u8, global.interface, wp.ColorManagerV1.interface.name) == .eq) {
+                if (globals.color_manager == null) {
+                    const manager = registry.bind(global.name, wp.ColorManagerV1, 1) catch return;
+                    globals.color_manager = manager;
+                    manager.setListener(*Globals, colorManagerListener, globals);
+                }
             }
         },
         .global_remove => |removed| {
@@ -1022,6 +1128,32 @@ fn registryListener(registry: *wl.Registry, event: wl.Registry.Event, globals: *
                 globals.seat_name = null;
             }
         },
+    }
+}
+
+fn shmListener(_: *wl.Shm, event: wl.Shm.Event, globals: *Globals) void {
+    switch (event) {
+        .format => |format| {
+            if (format.format == .abgr16161616) globals.shm_abgr16161616 = true;
+        },
+    }
+}
+
+fn colorManagerListener(_: *wp.ColorManagerV1, event: wp.ColorManagerV1.Event, globals: *Globals) void {
+    switch (event) {
+        .supported_intent => |supported| {
+            if (supported.render_intent == .perceptual) globals.cm_intent_perceptual = true;
+        },
+        .supported_feature => |supported| {
+            if (supported.feature == .parametric) globals.cm_feature_parametric = true;
+        },
+        .supported_tf_named => |supported| {
+            if (supported.tf == .ext_linear) globals.cm_tf_ext_linear = true;
+        },
+        .supported_primaries_named => |supported| {
+            if (supported.primaries == .srgb) globals.cm_primaries_srgb = true;
+        },
+        .done => {},
     }
 }
 

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -4,6 +4,8 @@
 //! RenderState update, full and dirty-row renders, and the frame copy
 //! into a swapchain buffer. The render target is heap memory, which
 //! behaves like the wl_shm buffer (both are plain anonymous pages).
+//! Every suite runs against the 8-bit sRGB target and the 16-bit linear
+//! target used by gamma-correct blending.
 
 const std = @import("std");
 const vt = @import("ghostty-vt");
@@ -33,6 +35,29 @@ pub fn run(init: std.process.Init) !void {
     var renderer: Renderer = try .init(alloc, &font, .{});
     defer renderer.deinit();
 
+    var out_buf: [4096]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(init.io, &out_buf);
+    const w = &stdout.interface;
+    defer w.flush() catch {};
+
+    try w.print(
+        "font {s} {d:.1}{s} ({d}px)\n\n8-bit sRGB target\n\n",
+        .{ config.font_family, config.font_size.value(), config.font_size.unit(), font_size_px },
+    );
+    try runFormat(init, alloc, config, &renderer, u32, w);
+    try w.writeAll("\n16-bit linear target (gamma-correct blending)\n\n");
+    try runFormat(init, alloc, config, &renderer, u64, w);
+}
+
+fn runFormat(
+    init: std.process.Init,
+    alloc: std.mem.Allocator,
+    config: Config,
+    renderer: *Renderer,
+    comptime P: type,
+    w: *std.Io.Writer,
+) !void {
+    const font = renderer.font;
     const width: u31 = font.cell_width * cols;
     const height: u31 = font.cell_height * rows;
 
@@ -51,24 +76,16 @@ pub fn run(init: std.process.Init) !void {
     var render_state: vt.RenderState = .empty;
     defer render_state.deinit(alloc);
 
-    const pixels = try alloc.alloc(u32, @as(usize, width) * height);
+    const pixels = try alloc.alloc(P, @as(usize, width) * height);
     defer alloc.free(pixels);
-    const shm = try alloc.alloc(u32, pixels.len);
+    const shm = try alloc.alloc(P, pixels.len);
     defer alloc.free(shm);
 
-    var out_buf: [4096]u8 = undefined;
-    var stdout = std.Io.File.stdout().writer(init.io, &out_buf);
-    const w = &stdout.interface;
-    defer w.flush() catch {};
-
     try w.print(
-        "grid {d}x{d}, {d}x{d} px ({d:.1} MB frame), font {s} {d:.1}{s} ({d}px)\n\n",
+        "grid {d}x{d}, {d}x{d} px ({d:.1} MB frame)\n\n",
         .{
-            cols,                                          rows,
-            width,                                         height,
-            @as(f64, @floatFromInt(pixels.len * 4)) / 1e6, config.font_family,
-            config.font_size.value(),                      config.font_size.unit(),
-            font_size_px,
+            cols,                                                   rows, width, height,
+            @as(f64, @floatFromInt(pixels.len * @sizeOf(P))) / 1e6,
         },
     );
 
@@ -145,16 +162,16 @@ pub fn run(init: std.process.Init) !void {
             @memcpy(shm, pixels);
             std.mem.doNotOptimizeAway(shm);
         }
-        try report(w, "copy full frame", nowNs(init.io) - start, iters, pixels.len * 4);
+        try report(w, "copy full frame", nowNs(init.io) - start, iters, pixels.len * @sizeOf(P));
     }
     {
         const iters = 300;
         const start = nowNs(init.io);
         for (0..iters) |_| {
-            _ = memcpy(shm.ptr, pixels.ptr, pixels.len * 4);
+            _ = memcpy(shm.ptr, pixels.ptr, pixels.len * @sizeOf(P));
             std.mem.doNotOptimizeAway(shm);
         }
-        try report(w, "copy full frame (libc)", nowNs(init.io) - start, iters, pixels.len * 4);
+        try report(w, "copy full frame (libc)", nowNs(init.io) - start, iters, pixels.len * @sizeOf(P));
     }
     {
         const iters = 300;
@@ -163,8 +180,8 @@ pub fn run(init: std.process.Init) !void {
             Renderer.copyPixels(shm, pixels);
             std.mem.doNotOptimizeAway(shm);
         }
-        try report(w, "copy full frame (NT stores)", nowNs(init.io) - start, iters, pixels.len * 4);
-        if (!std.mem.eql(u32, shm, pixels)) try w.writeAll("  (!) NT copy MISMATCH\n");
+        try report(w, "copy full frame (NT stores)", nowNs(init.io) - start, iters, pixels.len * @sizeOf(P));
+        if (!std.mem.eql(P, shm, pixels)) try w.writeAll("  (!) NT copy MISMATCH\n");
     }
     {
         // A typical partial frame: one dirty row expanded to three.
@@ -177,23 +194,23 @@ pub fn run(init: std.process.Init) !void {
             @memcpy(shm[offset..][0..span_len], pixels[offset..][0..span_len]);
             std.mem.doNotOptimizeAway(shm);
         }
-        try report(w, "copy 3-row span", nowNs(init.io) - start, iters, span_len * 4);
+        try report(w, "copy 3-row span", nowNs(init.io) - start, iters, span_len * @sizeOf(P));
     }
 
     try w.writeAll("\n4K-ish stress cases\n");
-    var row_renderer: Renderer = try .init(alloc, &font, .{
+    var row_renderer: Renderer = try .init(alloc, renderer.font, .{
         .track_cell_damage = false,
         .partial_cell_raster = false,
     });
     defer row_renderer.deinit();
-    try benchFullGrid(init.io, alloc, config, &row_renderer, w, 384, 112, "full render rows 384x112");
-    try benchShapePrefixChurn(init.io, alloc, config, &row_renderer, w, 384, 112, "prefix-churn rows 384x112", false);
-    try benchFullGrid(init.io, alloc, config, &renderer, w, 384, 112, "full render+cell snapshot 384x112");
-    try benchShapePrefixChurn(init.io, alloc, config, &renderer, w, 384, 112, "prefix-churn cells 384x112", false);
-    var pipeline_renderer: Renderer = try .init(alloc, &font, .{});
+    try benchFullGrid(init.io, alloc, config, &row_renderer, w, P, 384, 112, "full render rows 384x112");
+    try benchShapePrefixChurn(init.io, alloc, config, &row_renderer, w, P, 384, 112, "prefix-churn rows 384x112", false);
+    try benchFullGrid(init.io, alloc, config, renderer, w, P, 384, 112, "full render+cell snapshot 384x112");
+    try benchShapePrefixChurn(init.io, alloc, config, renderer, w, P, 384, 112, "prefix-churn cells 384x112", false);
+    var pipeline_renderer: Renderer = try .init(alloc, renderer.font, .{});
     defer pipeline_renderer.deinit();
-    try benchShapePrefixChurn(init.io, alloc, config, &pipeline_renderer, w, 384, 112, "prefix-churn cells+repair 384x112", true);
-    try benchCopies(init.io, alloc, w, 3840, 2160, "copy 3840x2160");
+    try benchShapePrefixChurn(init.io, alloc, config, &pipeline_renderer, w, P, 384, 112, "prefix-churn cells+repair 384x112", true);
+    try benchCopies(init.io, alloc, w, P, 3840, 2160, "copy 3840x2160");
 }
 
 fn benchFullGrid(
@@ -202,6 +219,7 @@ fn benchFullGrid(
     config: Config,
     renderer: *Renderer,
     w: *std.Io.Writer,
+    comptime P: type,
     comptime bench_cols: u16,
     comptime bench_rows: u16,
     comptime name: []const u8,
@@ -223,7 +241,7 @@ fn benchFullGrid(
     var render_state: vt.RenderState = .empty;
     defer render_state.deinit(alloc);
 
-    const pixels = try alloc.alloc(u32, @as(usize, width) * height);
+    const pixels = try alloc.alloc(P, @as(usize, width) * height);
     defer alloc.free(pixels);
 
     try fillScreenDims(alloc, &stream, bench_cols, bench_rows);
@@ -239,7 +257,7 @@ fn benchFullGrid(
             bench_rows,
             width,
             height,
-            @as(f64, @floatFromInt(pixels.len * 4)) / 1e6,
+            @as(f64, @floatFromInt(pixels.len * @sizeOf(P))) / 1e6,
         },
     );
 
@@ -255,17 +273,18 @@ fn benchCopies(
     io: std.Io,
     alloc: std.mem.Allocator,
     w: *std.Io.Writer,
+    comptime P: type,
     comptime width: usize,
     comptime height: usize,
     comptime name: []const u8,
 ) !void {
-    const pixels = try alloc.alloc(u32, width * height);
+    const pixels = try alloc.alloc(P, width * height);
     defer alloc.free(pixels);
-    const shm = try alloc.alloc(u32, pixels.len);
+    const shm = try alloc.alloc(P, pixels.len);
     defer alloc.free(shm);
     @memset(pixels, 0xff1a1b26);
 
-    const bytes = pixels.len * 4;
+    const bytes = pixels.len * @sizeOf(P);
     try w.print("{s}: {d}x{d} px ({d:.1} MB frame)\n", .{
         name,
         width,
@@ -298,7 +317,7 @@ fn benchCopies(
             std.mem.doNotOptimizeAway(shm);
         }
         try report(w, "copy 4K frame (NT stores)", nowNs(io) - start, iters, bytes);
-        if (!std.mem.eql(u32, shm, pixels)) try w.writeAll("  (!) NT copy MISMATCH\n");
+        if (!std.mem.eql(P, shm, pixels)) try w.writeAll("  (!) NT copy MISMATCH\n");
     }
 }
 
@@ -308,6 +327,7 @@ fn benchShapePrefixChurn(
     config: Config,
     renderer: *Renderer,
     w: *std.Io.Writer,
+    comptime P: type,
     comptime bench_cols: u16,
     comptime bench_rows: u16,
     name: []const u8,
@@ -332,7 +352,7 @@ fn benchShapePrefixChurn(
 
     const frame_len = @as(usize, width) * height;
     const buffer_count: usize = if (repair_stale_buffers) 3 else 1;
-    const buffers = try alloc.alloc(u32, frame_len * buffer_count);
+    const buffers = try alloc.alloc(P, frame_len * buffer_count);
     defer alloc.free(buffers);
     var damage_history: [2]std.ArrayList(Renderer.PixelRect) = .{ .empty, .empty };
     defer for (&damage_history) |*rects| rects.deinit(alloc);
@@ -357,7 +377,7 @@ fn benchShapePrefixChurn(
         if (repair_stale_buffers) {
             const history_len = @min(frame, damage_history.len);
             for (damage_history[0..history_len]) |rects| {
-                copyDamageRects(target, newest, width, rects.items);
+                copyDamageRects(P, target, newest, width, rects.items);
             }
         }
         try fillPrefixChurnFrame(alloc, &stream, bench_cols, bench_rows, frame + 1);
@@ -395,7 +415,7 @@ fn replaceCoalescedDamage(
     }
 }
 
-fn copyDamageRects(dest: []u32, source: []const u32, stride: u31, rects: []const Renderer.PixelRect) void {
+fn copyDamageRects(comptime P: type, dest: []P, source: []const P, stride: u31, rects: []const Renderer.PixelRect) void {
     for (rects) |rect| {
         for (rect.y..rect.y + rect.height) |y| {
             const offset = @as(usize, y) * stride + rect.x;

--- a/src/pixel_buffer.zig
+++ b/src/pixel_buffer.zig
@@ -1,0 +1,22 @@
+//! A tagged view over render-target storage: 8-bit sRGB pixels or 16-bit
+//! linear-light pixels. The active tag, not renderer state, selects the
+//! raster code path; renderers dispatch on it, buffer owners construct it.
+
+const std = @import("std");
+
+pub const PixelBuffer = union(enum) {
+    rgba8: []u32,
+    rgba16: []u64,
+
+    pub const Const = union(enum) {
+        rgba8: []const u32,
+        rgba16: []const u64,
+    };
+
+    pub fn asConst(self: PixelBuffer) Const {
+        return switch (self) {
+            .rgba8 => |pixels| .{ .rgba8 = pixels },
+            .rgba16 => |pixels| .{ .rgba16 = pixels },
+        };
+    }
+};

--- a/src/pixel_copy.zig
+++ b/src/pixel_copy.zig
@@ -11,11 +11,13 @@ const builtin = @import("builtin");
 /// the read-for-ownership of every destination cache line (about a
 /// third of the bus traffic) and keep the copy from evicting the
 /// render working set.
-pub fn copyPixels(noalias dst: []u32, noalias src: []const u32) void {
+pub fn copyPixels(noalias dst: anytype, noalias src: anytype) void {
+    const P = std.meta.Child(@TypeOf(dst));
+    std.debug.assert(P == std.meta.Child(@TypeOf(src)));
     std.debug.assert(dst.len == src.len);
     // Below this size the fence and alignment fixup outweigh the saved
     // traffic, and freshly written destination lines may still be hot.
-    const nt_threshold = 256 * 1024 / @sizeOf(u32);
+    const nt_threshold = 256 * 1024 / @sizeOf(P);
     // The self-hosted backend's assembler can't parse the SSE memory
     // operands, so the non-temporal path is LLVM-only (all release
     // builds; debug performance doesn't matter).
@@ -25,10 +27,10 @@ pub fn copyPixels(noalias dst: []u32, noalias src: []const u32) void {
     @memcpy(dst, src);
 }
 
-fn copyNonTemporal(noalias dst: []u32, noalias src: []const u32) void {
+fn copyNonTemporal(noalias dst: anytype, noalias src: anytype) void {
     var d: [*]u8 = @ptrCast(dst.ptr);
     var s: [*]const u8 = @ptrCast(src.ptr);
-    var n: usize = dst.len * @sizeOf(u32);
+    var n: usize = dst.len * @sizeOf(std.meta.Child(@TypeOf(dst)));
 
     // movntdq requires a 16-byte-aligned destination.
     const misalign = @intFromPtr(d) & 15;

--- a/src/pixel_raster.zig
+++ b/src/pixel_raster.zig
@@ -43,6 +43,14 @@ pub fn premultipliedArgb(rgb: vt.color.RGB, alpha_u8: u8) u32 {
     return (alpha << 24) | (r << 16) | (g << 8) | b;
 }
 
+/// Pack opaque foreign image bytes without color conversion. Kitty image
+/// data uses this: like foot's pixman pipeline, foreign pixels are treated
+/// as already being in the framebuffer's encoding (sRGB for 8-bit,
+/// linear-expanded for the 16-bit `linear` namespace).
+pub fn expandedArgb(r: u8, g: u8, b: u8) u32 {
+    return 0xff000000 | (@as(u32, r) << 16) | (@as(u32, g) << 8) | b;
+}
+
 pub fn fillRect(
     pixels: []u32,
     stride: u31,
@@ -386,6 +394,299 @@ fn blendPremultipliedBgra(src: []const u8, bg: u32) u32 {
     return (out_alpha << 24) | (r << 16) | (g << 8) | b;
 }
 
+/// Gamma-correct blending primitives for 16-bit linear-light framebuffers
+/// (WL_SHM_FORMAT_ABGR16161616, little-endian u64 pixels: R bits 0-15,
+/// G 16-31, B 32-47, A 48-63). Mirrors foot's gamma-correct-blending:
+/// terminal colors decode from sRGB to 16-bit linear at the color→pixel
+/// boundary, coverage blending runs in linear space, and the compositor
+/// converts linear→display because the surface is tagged as linear sRGB
+/// via wp-color-manager-v1. Foreign pixel data (color emoji, Kitty
+/// images) expands to 16-bit without decoding, the same tradeoff foot's
+/// pixman pipeline makes. Signatures mirror the 8-bit root namespace so
+/// render code can alias one of the two with a comptime pixel type.
+pub const linear = struct {
+    /// 8-bit sRGB to 16-bit linear decode table. Like foot, this uses a
+    /// pure 2.2 gamma rather than the piece-wise sRGB transfer function
+    /// because that is what compositors apply to tagged surfaces.
+    pub const srgb_decode_8_to_16_table: [256]u16 = blk: {
+        @setEvalBranchQuota(100_000);
+        var table: [256]u16 = undefined;
+        for (&table, 0..) |*entry, i| {
+            const c: f64 = @as(f64, @floatFromInt(i)) / 255.0;
+            entry.* = @intFromFloat(std.math.pow(f64, c, 2.2) * 65535.0 + 0.5);
+        }
+        break :blk table;
+    };
+
+    /// Pack an opaque color as a linear ABGR16161616 pixel.
+    pub fn argb(rgb: vt.color.RGB) u64 {
+        return @as(u64, 0xffff) << 48 |
+            @as(u64, srgb_decode_8_to_16_table[rgb.b]) << 32 |
+            @as(u64, srgb_decode_8_to_16_table[rgb.g]) << 16 |
+            @as(u64, srgb_decode_8_to_16_table[rgb.r]);
+    }
+
+    pub fn premultipliedArgb(rgb: vt.color.RGB, alpha_u8: u8) u64 {
+        const a: u64 = @as(u64, alpha_u8) * 257;
+        const r = (@as(u64, srgb_decode_8_to_16_table[rgb.r]) * a + 32767) / 65535;
+        const g = (@as(u64, srgb_decode_8_to_16_table[rgb.g]) * a + 32767) / 65535;
+        const b = (@as(u64, srgb_decode_8_to_16_table[rgb.b]) * a + 32767) / 65535;
+        return (a << 48) | (b << 32) | (g << 16) | r;
+    }
+
+    /// Pack opaque foreign image bytes without sRGB decoding, the same
+    /// tradeoff foot's pixman pipeline makes for 8-bit sources on its
+    /// 16-bit surface.
+    pub fn expandedArgb(r: u8, g: u8, b: u8) u64 {
+        return @as(u64, 0xffff) << 48 |
+            @as(u64, b) * 257 << 32 |
+            @as(u64, g) * 257 << 16 |
+            @as(u64, r) * 257;
+    }
+
+    pub fn fillRect(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        x: u31,
+        y: u31,
+        w: u31,
+        h: u31,
+        color: u64,
+    ) void {
+        if (x >= buf_width or y >= buf_height) return;
+        const x_end = @min(x + w, buf_width);
+        const y_end = @min(y + h, buf_height);
+        for (y..y_end) |row| {
+            linear.fillSpan(pixels[row * stride + x .. row * stride + x_end], color);
+        }
+    }
+
+    fn fillSpan(dst: []u64, color: u64) void {
+        const V = @Vector(4, u64);
+        const splat: V = @splat(color);
+        var i: usize = 0;
+        while (i + 4 <= dst.len) : (i += 4) dst[i..][0..4].* = splat;
+        for (dst[i..]) |*px| px.* = color;
+    }
+
+    pub fn blendCapsule(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        thumb: ScrollbarThumb,
+        color: u64,
+    ) void {
+        if (thumb.alpha == 0 or thumb.width == 0 or thumb.height == 0 or
+            thumb.x >= buf_width or thumb.y >= buf_height) return;
+        std.debug.assert(color >> 48 == 0xffff);
+
+        const x_end = @min(thumb.x + thumb.width, buf_width);
+        const y_end = @min(thumb.y + thumb.height, buf_height);
+        const radius = @as(f64, @floatFromInt(@min(thumb.width, thumb.height))) / 2.0;
+        const center_x = @as(f64, @floatFromInt(thumb.x)) +
+            @as(f64, @floatFromInt(thumb.width)) / 2.0;
+        const cap_top = @as(f64, @floatFromInt(thumb.y)) + radius;
+        const cap_bottom = @as(f64, @floatFromInt(thumb.y + thumb.height)) - radius;
+
+        for (thumb.y..y_end) |y| {
+            const py = @as(f64, @floatFromInt(y)) + 0.5;
+            const nearest_y = std.math.clamp(py, cap_top, cap_bottom);
+            for (thumb.x..x_end) |x| {
+                const px = @as(f64, @floatFromInt(x)) + 0.5;
+                const dx = px - center_x;
+                const dy = py - nearest_y;
+                // One pixel of coverage around the mathematical edge gives the
+                // small pill smooth caps without involving the vector renderer.
+                const coverage = std.math.clamp(radius + 0.5 - @sqrt(dx * dx + dy * dy), 0, 1);
+                if (coverage == 0) continue;
+                const alpha: u16 = @intFromFloat(@round(@as(f64, @floatFromInt(thumb.alpha)) * 257.0 * coverage));
+                const pixel = &pixels[@as(usize, y) * stride + x];
+                pixel.* = linear.blend(color, pixel.*, alpha);
+            }
+        }
+    }
+
+    /// Alpha-blend an 8-bit coverage bitmap in `color` over the buffer.
+    pub fn blitGlyph(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        g: *const Font.Glyph,
+        x0: i32,
+        y0: i32,
+        color: u64,
+        reverse_color_glyph: bool,
+        clip_x: ?PixelRange,
+    ) void {
+        switch (g.format) {
+            .alpha => if (g.fully_opaque)
+                linear.blitOpaqueGlyph(pixels, stride, buf_width, buf_height, g, x0, y0, color, clip_x)
+            else
+                linear.blitAlphaGlyph(pixels, stride, buf_width, buf_height, g, x0, y0, color, clip_x),
+            .bgra => if (reverse_color_glyph)
+                linear.blitBgraGlyphAsAlpha(pixels, stride, buf_width, buf_height, g, x0, y0, color, clip_x)
+            else
+                linear.blitBgraGlyph(pixels, stride, buf_width, buf_height, g, x0, y0, clip_x),
+        }
+    }
+
+    fn blitOpaqueGlyph(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        g: *const Font.Glyph,
+        x0: i32,
+        y0: i32,
+        color: u64,
+        clip_x: ?PixelRange,
+    ) void {
+        const clip = clipGlyph(g, x0, y0, buf_width, buf_height, clip_x) orelse return;
+        const px_start: usize = @intCast(x0 + @as(i32, @intCast(clip.gx_start)));
+        const span_len = clip.gx_end - clip.gx_start;
+        for (clip.gy_start..clip.gy_end) |gy| {
+            const py: usize = @intCast(y0 + @as(i32, @intCast(gy)));
+            linear.fillSpan(pixels[py * stride + px_start ..][0..span_len], color);
+        }
+    }
+
+    fn blitAlphaGlyph(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        g: *const Font.Glyph,
+        x0: i32,
+        y0: i32,
+        color: u64,
+        clip_x: ?PixelRange,
+    ) void {
+        const clip = clipGlyph(g, x0, y0, buf_width, buf_height, clip_x) orelse return;
+        const px_start: usize = @intCast(x0 + @as(i32, @intCast(clip.gx_start)));
+        for (clip.gy_start..clip.gy_end) |gy| {
+            const py: usize = @intCast(y0 + @as(i32, @intCast(gy)));
+            const src = g.bitmap[gy * g.width + clip.gx_start .. gy * g.width + clip.gx_end];
+            const dst = pixels[py * stride + px_start ..][0..src.len];
+            linear.blendAlphaSpan(dst, src, color);
+        }
+    }
+
+    /// Scalar counterpart of the 8-bit blendAlphaSpan: coverage expands
+    /// to 16-bit (v*257, pixman's mask expansion) and blending runs on
+    /// the linear 16-bit channels. Zero-coverage pixels keep their
+    /// background; full coverage stores the foreground unchanged.
+    fn blendAlphaSpan(noalias dst: []u64, noalias coverage: []const u8, color: u64) void {
+        std.debug.assert(dst.len == coverage.len);
+        std.debug.assert(color >> 48 == 0xffff);
+        for (dst, coverage) |*pixel, cov| {
+            if (cov == 0) continue;
+            if (cov == 0xff) {
+                pixel.* = color;
+                continue;
+            }
+            pixel.* = linear.blend(color, pixel.*, @as(u16, cov) * 257);
+        }
+    }
+
+    fn blitBgraGlyph(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        g: *const Font.Glyph,
+        x0: i32,
+        y0: i32,
+        clip_x: ?PixelRange,
+    ) void {
+        const clip = clipGlyph(g, x0, y0, buf_width, buf_height, clip_x) orelse return;
+        const px_start: usize = @intCast(x0 + @as(i32, @intCast(clip.gx_start)));
+        for (clip.gy_start..clip.gy_end) |gy| {
+            const src = g.bitmap[(gy * g.width + clip.gx_start) * 4 ..];
+            const py: usize = @intCast(y0 + @as(i32, @intCast(gy)));
+            const dst = pixels[py * stride + px_start ..][0 .. clip.gx_end - clip.gx_start];
+            for (dst, 0..) |*pixel, i| {
+                const cell = src[i * 4 ..][0..4];
+                if (cell[3] == 0) continue;
+                pixel.* = linear.blendPremultipliedBgra(cell, pixel.*);
+            }
+        }
+    }
+
+    fn blitBgraGlyphAsAlpha(
+        pixels: []u64,
+        stride: u31,
+        buf_width: u31,
+        buf_height: u31,
+        g: *const Font.Glyph,
+        x0: i32,
+        y0: i32,
+        color: u64,
+        clip_x: ?PixelRange,
+    ) void {
+        const clip = clipGlyph(g, x0, y0, buf_width, buf_height, clip_x) orelse return;
+        const px_start: usize = @intCast(x0 + @as(i32, @intCast(clip.gx_start)));
+        for (clip.gy_start..clip.gy_end) |gy| {
+            const src = g.bitmap[(gy * g.width + clip.gx_start) * 4 ..];
+            const py: usize = @intCast(y0 + @as(i32, @intCast(gy)));
+            const dst = pixels[py * stride + px_start ..][0 .. clip.gx_end - clip.gx_start];
+            for (dst, 0..) |*pixel, i| {
+                const alpha = src[i * 4 + 3];
+                if (alpha == 0) continue;
+                pixel.* = linear.blend(color, pixel.*, @as(u16, alpha) * 257);
+            }
+        }
+    }
+
+    fn blend(fg: u64, bg: u64, alpha: u16) u64 {
+        if (alpha == 0xffff) return fg;
+        const a: u64 = alpha;
+        const na: u64 = 65535 - a;
+        const r = ((fg & 0xffff) * a + (bg & 0xffff) * na) / 65535;
+        const g = ((fg >> 16 & 0xffff) * a + (bg >> 16 & 0xffff) * na) / 65535;
+        const b = ((fg >> 32 & 0xffff) * a + (bg >> 32 & 0xffff) * na) / 65535;
+        const out_alpha = ((fg >> 48) * a + (bg >> 48) * na) / 65535;
+        return (out_alpha << 48) | (b << 32) | (g << 16) | r;
+    }
+
+    pub fn blendPixel(dst: u64, src: *const [4]u8) u64 {
+        const alpha = @as(u64, src[3]) * 257;
+        const inv_alpha = 65535 - alpha;
+        const dst_r = dst & 0xffff;
+        const dst_g = (dst >> 16) & 0xffff;
+        const dst_b = (dst >> 32) & 0xffff;
+        const dst_a = dst >> 48;
+        const r = (@as(u64, src[0]) * 257 * alpha + dst_r * inv_alpha + 32767) / 65535;
+        const g = (@as(u64, src[1]) * 257 * alpha + dst_g * inv_alpha + 32767) / 65535;
+        const b = (@as(u64, src[2]) * 257 * alpha + dst_b * inv_alpha + 32767) / 65535;
+        const a = (65535 * alpha + dst_a * inv_alpha + 32767) / 65535;
+        return (a << 48) | (b << 32) | (g << 16) | r;
+    }
+
+    /// Blend 8-bit premultiplied BGRA over the linear buffer. The source
+    /// channels expand to 16-bit without sRGB decoding: they are treated
+    /// as linear, exactly what foot's pixman pipeline does when
+    /// compositing 8-bit emoji onto its 16-bit surface.
+    fn blendPremultipliedBgra(src: []const u8, bg: u64) u64 {
+        const a: u64 = @as(u64, src[3]) * 257;
+        const r16 = @as(u64, src[2]) * 257;
+        const g16 = @as(u64, src[1]) * 257;
+        const b16 = @as(u64, src[0]) * 257;
+        if (a == 0xffff) {
+            return (a << 48) | (b16 << 32) | (g16 << 16) | r16;
+        }
+        const na: u64 = 65535 - a;
+        const out_alpha: u64 = @min(65535, a + ((bg >> 48) * na) / 65535);
+        const r: u64 = @min(out_alpha, r16 + ((bg & 0xffff) * na) / 65535);
+        const g: u64 = @min(out_alpha, g16 + ((bg >> 16 & 0xffff) * na) / 65535);
+        const b: u64 = @min(out_alpha, b16 + ((bg >> 32 & 0xffff) * na) / 65535);
+        return (out_alpha << 48) | (b << 32) | (g << 16) | r;
+    }
+};
+
 test "fillRect clips to a view while honoring framebuffer stride" {
     const untouched: u32 = 0x12345678;
     var pixels = [_]u32{untouched} ** 15;
@@ -579,5 +880,117 @@ test "blendPremultipliedBgraSpan matches scalar blend" {
             blendPremultipliedBgraSpan(got[0..len], source[0 .. len * 4]);
             try std.testing.expectEqualSlices(u32, want[0..len], got[0..len]);
         }
+    }
+}
+
+test "linear sRGB decode table matches pure 2.2 gamma" {
+    const table = &linear.srgb_decode_8_to_16_table;
+    try std.testing.expectEqual(@as(u16, 0), table[0]);
+    try std.testing.expectEqual(@as(u16, 14386), table[128]);
+    try std.testing.expectEqual(@as(u16, 64971), table[254]);
+    try std.testing.expectEqual(@as(u16, 65535), table[255]);
+    for (1..256) |i| try std.testing.expect(table[i] >= table[i - 1]);
+}
+
+test "linear argb packs opaque premultiplied ABGR16161616" {
+    const white: vt.color.RGB = .{ .r = 0xff, .g = 0xff, .b = 0xff };
+    const black: vt.color.RGB = .{ .r = 0, .g = 0, .b = 0 };
+    try std.testing.expectEqual(@as(u64, 0xffff_ffff_ffff_ffff), linear.argb(white));
+    try std.testing.expectEqual(@as(u64, 0xffff_0000_0000_0000), linear.argb(black));
+    const red: vt.color.RGB = .{ .r = 0xff, .g = 0, .b = 0 };
+    try std.testing.expectEqual(@as(u64, 0xffff_0000_0000_ffff), linear.argb(red));
+}
+
+test "linear premultipliedArgb endpoints" {
+    const rgb: vt.color.RGB = .{ .r = 255, .g = 255, .b = 255 };
+    try std.testing.expectEqual(@as(u64, 0), linear.premultipliedArgb(rgb, 0));
+    try std.testing.expectEqual(linear.argb(rgb), linear.premultipliedArgb(rgb, 255));
+    // Half alpha premultiplies the linear channel by the same fraction.
+    try std.testing.expectEqual(@as(u64, 0x8080_8080_8080_8080), linear.premultipliedArgb(rgb, 128));
+}
+
+test "linear blend endpoints" {
+    const opaque_white: u64 = 0xffff_ffff_ffff_ffff;
+    const opaque_black: u64 = 0xffff_0000_0000_0000;
+    try std.testing.expectEqual(opaque_white, linear.blend(opaque_white, opaque_black, 0xffff));
+    try std.testing.expectEqual(opaque_black, linear.blend(opaque_white, opaque_black, 0));
+    try std.testing.expectEqual(
+        @as(u64, 0xffff_8000_8000_8000),
+        linear.blend(opaque_white, opaque_black, 0x8000),
+    );
+}
+
+test "linear blendPixel expands opaque sources and keeps covered pixels" {
+    const dst: u64 = 0xffff_1000_2000_3000;
+    try std.testing.expectEqual(dst, linear.blendPixel(dst, &.{ 200, 100, 50, 0 }));
+    try std.testing.expectEqual(
+        @as(u64, 0xffff_0000_0000_0000 | (30 * 257 << 32) | (20 * 257 << 16) | (10 * 257)),
+        linear.blendPixel(dst, &.{ 10, 20, 30, 255 }),
+    );
+}
+
+test "linear premultiplied BGRA clamps channels to alpha" {
+    // Imperfectly premultiplied glyphs (color > alpha) must clamp to the
+    // resulting alpha so the premultiplied invariant holds.
+    const over: [4]u8 = .{ 255, 255, 255, 128 };
+    const bg: u64 = 0xffff_ffff_ffff_ffff;
+    const pixel = linear.blendPremultipliedBgra(&over, bg);
+    const alpha = pixel >> 48;
+    try std.testing.expect(pixel & 0xffff <= alpha);
+    try std.testing.expect(pixel >> 16 & 0xffff <= alpha);
+    try std.testing.expect(pixel >> 32 & 0xffff <= alpha);
+
+    const opaque_px = linear.blendPremultipliedBgra(&.{ 10, 20, 30, 255 }, bg);
+    // BGRA byte order: B lands at bits 32-47, R at bits 0-15.
+    try std.testing.expectEqual(
+        @as(u64, 0xffff_0000_0000_0000 | (10 * 257 << 32) | (20 * 257 << 16) | (30 * 257)),
+        opaque_px,
+    );
+}
+
+test "linear opaque glyph fast path matches alpha blending with clipping" {
+    const bitmap: [12]u8 = @splat(0xff);
+    const alpha_glyph: Font.Glyph = .{
+        .bitmap = @constCast(&bitmap),
+        .width = 4,
+        .height = 3,
+        .bearing_x = 0,
+        .bearing_y = 0,
+    };
+    var opaque_glyph = alpha_glyph;
+    opaque_glyph.fully_opaque = true;
+
+    var alpha_pixels: [5 * 4]u64 = @splat(0xffff_1234_5678_9abc);
+    var opaque_pixels = alpha_pixels;
+    linear.blitGlyph(&alpha_pixels, 5, 5, 4, &alpha_glyph, -1, 2, 0xffff_abcd_ef01_2345, false, null);
+    linear.blitGlyph(&opaque_pixels, 5, 5, 4, &opaque_glyph, -1, 2, 0xffff_abcd_ef01_2345, false, null);
+    try std.testing.expectEqualSlices(u64, &alpha_pixels, &opaque_pixels);
+}
+
+test "linear alpha glyph blending matches scalar blend" {
+    const bitmap: [12]u8 = .{ 0, 1, 32, 64, 128, 192, 255, 7, 99, 200, 23, 250 };
+    const glyph: Font.Glyph = .{
+        .bitmap = @constCast(&bitmap),
+        .width = 4,
+        .height = 3,
+        .bearing_x = 0,
+        .bearing_y = 0,
+    };
+    const color: u64 = 0xffff_abcd_ef01_2345;
+    var pixels: [5 * 4]u64 = @splat(0xffff_1111_2222_3333);
+    linear.blitGlyph(&pixels, 5, 5, 4, &glyph, -1, 2, color, false, null);
+    for (bitmap, 0..) |cov, i| {
+        // x0 = -1 clips bitmap column 0; buf_height = 4 clips glyph row 2.
+        const x: i32 = @as(i32, @intCast(i % 4)) - 1;
+        const y = 2 + i / 4;
+        if (x < 0 or y >= 4) continue;
+        const px = pixels[y * 5 + @as(usize, @intCast(x))];
+        const want: u64 = if (cov == 0)
+            0xffff_1111_2222_3333
+        else if (cov == 0xff)
+            color
+        else
+            linear.blend(color, 0xffff_1111_2222_3333, @as(u16, cov) * 257);
+        try std.testing.expectEqual(want, px);
     }
 }


### PR DESCRIPTION
Ran benchmarks as well

## 240x64 grid (2400x1472 px)

Frame size doubles from 14.1 MB (8-bit) to 28.3 MB (16-bit).

| Benchmark                            | 8-bit sRGB           | 16-bit linear        | Ratio |
|--------------------------------------|----------------------|----------------------|-------|
| full render                          | 1.813 ms             | 4.181 ms             | 2.3x  |
| full render (bg-heavy)               | 1.515 ms             | 4.079 ms             | 2.7x  |
| scroll frame (feed+update+render)    | 0.201 ms             | 0.214 ms             | ~1x   |
| one-row frame (feed+update+render)   | 0.004 ms             | 0.003 ms             | ~1x   |
| copy full frame                      | 0.585 ms (24.2 GB/s) | 1.301 ms (21.7 GB/s) | 2.2x  |
| copy full frame (libc)               | 0.585 ms (24.1 GB/s) | 1.291 ms (21.9 GB/s) | 2.2x  |
| copy full frame (NT stores)          | 0.251 ms (56.3 GB/s) | 1.029 ms (27.5 GB/s) | 4.1x  |
| copy 3-row span                      | 0.012 ms (56.4 GB/s) | 0.024 ms (55.5 GB/s) | 2x    |

## 4K-ish stress cases (384x112 grid, 3840x2576 px)

Frame size doubles from 39.6 MB (8-bit) to 79.1 MB (16-bit).

| Benchmark                        | 8-bit sRGB           | 16-bit linear        | Ratio |
|----------------------------------|----------------------|----------------------|-------|
| full render rows 384x112         | 5.219 ms             | 11.855 ms            | 2.3x  |
| prefix-churn rows 384x112        | 4.611 ms             | 10.843 ms            | 2.4x  |
| full render+cell snapshot        | 5.644 ms             | 12.225 ms            | 2.2x  |
| prefix-churn cells 384x112       | 1.044 ms             | 1.165 ms             | 1.1x  |
| prefix-churn cells+repair        | 1.077 ms             | 1.495 ms             | 1.4x  |
| copy 4K frame                    | 1.634 ms (20.3 GB/s) | 3.695 ms (18.0 GB/s) | 2.3x  |
| copy 4K frame (libc)             | 1.565 ms (21.2 GB/s) | 3.768 ms (17.6 GB/s) | 2.4x  |
| copy 4K frame (NT stores)        | 1.192 ms (27.8 GB/s) | 2.417 ms (27.5 GB/s) | 2x    |
